### PR TITLE
feat(web): retire payload-QR; /pair is canonical AMK transfer UX

### DIFF
--- a/crates/secrt-server/CHANGELOG.md
+++ b/crates/secrt-server/CHANGELOG.md
@@ -16,6 +16,17 @@
 
   Spec: `spec/v1/server.md` § 6.4, `spec/v1/api.md` § Web-to-Web Pairing. Files: `crates/secrt-server/src/http/mod.rs`, `crates/secrt-server/src/storage/{mod,postgres}.rs`. Task: #68.
 
+### Changed
+
+- **Payload-QR retired on the AMK sync path; `/pair` is now the canonical browser-to-browser AMK transfer UX.** The link-based sync transport (`SyncNotesKeyButton` + `/sync/{id}#<urlKey>`) remains available as an asynchronous fallback for cases where both browsers cannot be open simultaneously, but the source-browser UI no longer renders the sync URL as a QR code.
+
+  Why: sync URLs are bearer-equivalent to the AMK itself. Rendering a bearer URL as a QR invites offline capture (camera shoulder-surf, projected slide, screen recording) without giving any UX win over direct copy/paste between trusted devices. The Web-to-Web Pairing flow keeps wrapping material entirely on user devices and binds the rendezvous slot to a single `user_id`, so the QR it does render is provably safe (encodes only the public `user_code`, useless without a same-user session).
+
+  - Web: `web/src/features/send/ShareResult.tsx` grows a `showQr?: boolean` prop (default `true` — normal one-shot secrets are unaffected). `web/src/components/SyncNotesKeyButton.tsx` passes `showQr={false}`. Dashboard/Settings demote `SyncNotesKeyButton` under the primary `/pair` call-to-action.
+  - Docs: `docs/whitepaper.md § Cross-Device Sync` rewritten to lead with the rendezvous primitive and frame the sync link as the async fallback. New "Pair-rendezvous interception" entry in the Threat Analysis. `spec/v1/api.md § Sync secrets` adds a normative pointer to §Web-to-Web Pairing and a MUST NOT clause on rendering sync URLs as QR. `spec/v1/server.md § Route Surface` now lists `GET /pair` explicitly with a cross-link to §6.4.
+
+  No wire-format change; CLI is unaffected. Files: `web/src/features/send/ShareResult.tsx`, `web/src/components/SyncNotesKeyButton.tsx`, `web/src/features/dashboard/DashboardPage.tsx`, `web/src/features/settings/SettingsPage.tsx`, `docs/whitepaper.md`, `spec/v1/api.md`, `spec/v1/server.md`. Task: #68 (PR 3 of 3).
+
 ### Fixed
 
 - **Web footer stays above mobile browser chrome.** The shared web/Tauri app shell now uses the dynamic viewport height so short pages keep the footer visible above mobile browser toolbars, with safe-area padding preserved for hardware insets.

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -516,17 +516,35 @@ On a new device, the client retrieves the wrapped blob, derives the same wrap ke
 
 ### Cross-Device Sync
 
-For users who want to sync the AMK to another browser without configuring an API key on that device, secrt provides a manual sync mechanism that tunnels through the existing one-time secret infrastructure:
+For users who want to sync the AMK to another browser without configuring an API key on that device, secrt provides two transports, both client-driven and zero-knowledge to the server.
+
+#### Browser-to-browser pairing (`/pair`, recommended)
+
+The primary path is a synchronous rendezvous between two same-account sessions, modelled on the CLI device-auth flow:
+
+1. **Displayer:** One browser visits `/pair` and posts to `/api/v1/auth/pair/start`, which returns an 8-character `user_code` (formatted `XXXX-XXXX`) and the displayer's poll token. The browser renders the code as text and as a QR encoding only `https://<host>/pair?mode=join&code=XXXX-XXXX` — no key material in the QR, ever.
+
+2. **Joiner:** The second browser visits the QR-linked URL (or types the code by hand) and posts to `/api/v1/auth/pair/claim`. Both sides exchange ephemeral P-256 ECDH public keys, derive an identical transfer key via HKDF, and the AMK-holding side encrypts the AMK with AES-256-GCM against that key.
+
+3. **Receiver-side commit-before-store:** Before persisting the decrypted AMK to IndexedDB, the receiver fetches its account's `amk_commit` from the server and verifies that the decrypted bytes hash to the same commit. A mismatch refuses the store and clears local state.
+
+4. **Slot lifecycle:** The rendezvous slot lives in `webauthn_challenges` with a 10-minute TTL and is deleted atomically on the receiver's first successful poll. The reaper deletes unconsumed slots at expiry. The server only ever sees public ECDH keys, the public `user_code`, and ciphertext.
+
+This path keeps wrapping secrets entirely on the user's devices — no third party (cloud clipboard, browser history, password manager, message archive) sees even ciphertext. The user-visible `user_code` is the public rendezvous identifier and is safe to display, encode in QR, and type by hand; the private poll tokens are session-bound and never embedded in URLs or QR codes. See `spec/v1/server.md` §6.4 for the full state machine, threat model, and privacy posture.
+
+#### Sync link (asynchronous fallback)
+
+When the two browsers cannot be open simultaneously, secrt also exposes a link-based fallback that tunnels through the existing one-time secret pipeline:
 
 1. **Source browser:** The `SyncNotesKeyButton` component seals the raw AMK bytes as a standard one-time secret (using the existing envelope encryption) with a short 10-minute TTL.
 
-2. **Sync link:** A `/sync/{id}#<urlKey>` URL is generated and displayed to the user (via QR code or copy/paste).
+2. **Sync link:** A `/sync/{id}#<urlKey>` URL is generated and displayed to the user for copy/paste. The UI deliberately does not render this URL as a QR code: sync URLs are bearer tokens equivalent in sensitivity to the AMK itself, and an offline screen capture or shoulder-surf of a QR is a strictly larger surface than copy/paste between trusted devices.
 
-3. **Target browser:** Opening the sync link routes to a dedicated `SyncPage` that claims the one-time secret, decrypts the envelope to recover the raw AMK, validates it is exactly 32 bytes, and stores it in IndexedDB.
+3. **Target browser:** Opening the sync link routes to a dedicated `SyncPage` that claims the one-time secret, decrypts the envelope to recover the raw AMK, validates it is exactly 32 bytes, runs the same commit-before-store check as the pairing path, and stores it in IndexedDB.
 
 4. **Self-destruct:** The secret is consumed by the one-time claim, so the link cannot be reused. The short TTL limits the exposure window.
 
-This reuses the existing zero-knowledge secret sharing pipeline — no new crypto, no new server endpoints — just a specialized UI flow for transferring the AMK between browsers.
+This reuses the existing zero-knowledge secret sharing pipeline — no new crypto, no new server endpoints — just a specialized UI flow for transferring the AMK between browsers when synchronous pairing isn't practical.
 
 ### CLI Device Authorization & ECDH Transfer
 
@@ -623,7 +641,9 @@ The commitment is blinded (the domain tag prevents rainbow table attacks) and re
 
 **IndexedDB exposure:** If an attacker gains access to the browser's IndexedDB on a logged-in device, they can extract the raw AMK and decrypt all notes. This is equivalent to the existing threat model non-goal of compromised client devices — if the attacker owns the browser, they can read anything the user can read.
 
-**Sync link interception:** A sync link is a standard one-time secret with a 10-minute TTL. The same protections apply: HTTPS transport, URL fragment key separation, one-time atomic claim. An attacker would need to both intercept the link and claim it before the user does.
+**Pair-rendezvous interception:** The `user_code` displayed by `/pair` and encoded in its QR is a public rendezvous identifier; possessing it is not sufficient to retrieve any AMK material. Every `/api/v1/auth/pair/*` endpoint requires a same-user session and the slot is bound to a single `user_id` at `/start`, so an attacker who intercepts the QR cannot claim or approve the slot without already controlling a session on the target account. AMK material in transit is sealed under the AES-GCM key derived from the two ephemeral P-256 keys via HKDF; the server only sees ciphertext.
+
+**Sync link interception:** A sync link is a standard one-time secret with a 10-minute TTL. The same protections apply: HTTPS transport, URL fragment key separation, one-time atomic claim. An attacker would need to both intercept the link and claim it before the user does. Because sync URLs are themselves bearer-equivalent to the AMK, the UI does not render them as QR codes — the `/pair` flow is the recommended path when synchronous transfer is possible.
 
 **AMK commitment mismatch:** A compromised server could accept a second, attacker-controlled AMK commitment. However, this only affects future notes encrypted with the forked AMK — existing notes remain bound to the original AMK and cannot be re-encrypted without it. Additionally, the attacker would still need a valid API key root secret to wrap and upload the forged AMK, which the server doesn't have.
 

--- a/spec/v1/api.md
+++ b/spec/v1/api.md
@@ -1295,6 +1295,8 @@ Browser support for the PRF extension is bleeding-edge (Chrome 147+, Safari 18+,
 
 A **sync secret** is a short-lived one-time secret whose plaintext is the raw 32-byte AMK. Sync secrets reuse the standard secret infrastructure; the server makes no protocol-level distinction from any other secret. The "sync" distinction exists entirely at the client layer.
 
+> **Browser-to-browser preferred path.** When both browsers are available simultaneously, clients SHOULD use the Web-to-Web Pairing flow (`/api/v1/auth/pair/*`, see `spec/v1/server.md` §6.4 and §Web-to-Web Pairing above) instead of the sync-secret transport. The pair flow keeps wrapping material entirely on user devices — no third party (cloud clipboard, browser history, password manager) sees even ciphertext — and binds the slot to a single `user_id` so the public rendezvous QR cannot be claimed by an unauthenticated observer. Sync secrets remain the documented asynchronous fallback when synchronous pairing is impractical.
+
 ##### Create side (browser)
 
 1. Read the 32-byte AMK from local storage.
@@ -1328,6 +1330,7 @@ Residual risks clients SHOULD surface to users when presenting a sync URL:
 - **Clipboard sync** — Apple Universal Clipboard, Windows Cloud Clipboard, and similar features replicate clipboards across devices and may expose the URL to unintended hosts.
 - **Browser history and password managers** — pasting a sync URL into a browser address bar may be captured by history, sync, or URL-grabbing password managers.
 - **Terminal logs** — pasting a sync URL into a terminal captures it in shell history and any remote logging.
+- **QR rendering** — because the URL itself is bearer-equivalent to the AMK, clients MUST NOT render sync URLs as QR codes. A QR code is trivial to capture out-of-band (camera shoulder-surf, projected slide, screen recording) and offers no value over direct copy/paste between trusted devices. The QR-coded transport for AMK transfer is the Web-to-Web Pairing flow, whose QR encodes only the public `user_code`.
 
 Treat sync URLs as ephemeral transfer material: consume immediately on the destination device, do not persist or bookmark.
 

--- a/spec/v1/server.md
+++ b/spec/v1/server.md
@@ -178,6 +178,7 @@ The header is an internal signal between the reverse proxy and the application a
 - `GET /api/v1/apikeys`
 - `POST /api/v1/apikeys/{prefix}/revoke`
 - `GET /device`
+- `GET /pair` (SPA marker for the Web-to-Web Pairing flow; serves the same index.html as `/`. See §6.4 and `api.md § Web-to-Web Pairing` for the protocol.)
 - `POST /api/v1/auth/device/start`
 - `POST /api/v1/auth/device/poll`
 - `POST /api/v1/auth/device/approve`

--- a/web/src/components/SyncNotesKeyButton.tsx
+++ b/web/src/components/SyncNotesKeyButton.tsx
@@ -118,6 +118,7 @@ export function SyncNotesKeyButton() {
             title="Notes Key Link"
             subtitle="Open link in the browser you want to sync."
             bare
+            showQr={false}
           />
         )}
 

--- a/web/src/features/dashboard/DashboardPage.tsx
+++ b/web/src/features/dashboard/DashboardPage.tsx
@@ -539,7 +539,16 @@ function DashboardContent() {
           Pair with another device
         </a>
 
-        <SyncNotesKeyButton />
+        {hasAmk && (
+          <details class="text-center">
+            <summary class="link-subtle cursor-pointer text-sm text-muted">
+              More options
+            </summary>
+            <div class="mt-2">
+              <SyncNotesKeyButton />
+            </div>
+          </details>
+        )}
       </div>
 
       {/* Secret detail modal */}

--- a/web/src/features/send/ShareResult.tsx
+++ b/web/src/features/send/ShareResult.tsx
@@ -66,6 +66,10 @@ interface ShareResultProps {
   resetLabel?: string;
   /** Skip the outer card wrapper (e.g. when rendered inside a modal). */
   bare?: boolean;
+  /** Render the QR encoding of `shareUrl`. Defaults to true. The AMK-sync
+   * flow disables this — sync URLs are too sensitive to invite an offline
+   * scan-and-walk-away threat surface. */
+  showQr?: boolean;
 }
 
 export function ShareResult({
@@ -76,6 +80,7 @@ export function ShareResult({
   subtitle,
   resetLabel = 'Send Another Secret',
   bare = false,
+  showQr = true,
 }: ShareResultProps) {
   return (
     <div class={bare ? 'space-y-5' : 'card space-y-5'}>
@@ -125,9 +130,11 @@ export function ShareResult({
         )}
       </div>
 
-      <div class="mt-7 flex justify-center">
-        <QrCanvas url={shareUrl} />
-      </div>
+      {showQr && (
+        <div class="mt-7 flex justify-center">
+          <QrCanvas url={shareUrl} />
+        </div>
+      )}
 
       <div>
         <p class="mb-1 text-center text-sm">

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -923,6 +923,10 @@ function SettingsContent() {
           >
             Pair Another Device
           </button>
+          <p class="text-sm text-muted">
+            Pairing is the recommended path. If both browsers can't be open
+            at the same time, you can use the link-based fallback below.
+          </p>
           <SyncNotesKeyButton />
         </div>
       </div>

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -906,30 +906,48 @@ function AccountCard() {
   );
 }
 
+function NotesKeyCard() {
+  const auth = useAuth();
+  const [hasAmk, setHasAmk] = useState(false);
+
+  useEffect(() => {
+    if (!auth.userId) return;
+    loadAmk(auth.userId).then((amk) => setHasAmk(amk !== null));
+  }, [auth.userId]);
+
+  return (
+    <div class="card">
+      <CardHeading
+        title="Notes Key"
+        subtitle="Allow your encrypted notes to be viewed on another browser or device."
+        class="mb-3"
+      />
+      <div class="flex flex-col items-center gap-3 text-center">
+        <button
+          type="button"
+          class="btn btn-primary tracking-wider uppercase"
+          onClick={() => navigate('/pair?mode=display&role=send')}
+        >
+          Pair Another Device
+        </button>
+        {hasAmk && (
+          <>
+            <p class="text-sm text-muted">
+              Pairing is the recommended path. If both browsers can't be open
+              at the same time, you can use the link-based fallback below.
+            </p>
+            <SyncNotesKeyButton />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function SettingsContent() {
   return (
     <div class="space-y-4">
-      <div class="card">
-        <CardHeading
-          title="Notes Key"
-          subtitle="Allow your encrypted notes to be viewed on another browser or device."
-          class="mb-3"
-        />
-        <div class="flex flex-col items-center gap-3 text-center">
-          <button
-            type="button"
-            class="btn btn-primary tracking-wider uppercase"
-            onClick={() => navigate('/pair?mode=display&role=send')}
-          >
-            Pair Another Device
-          </button>
-          <p class="text-sm text-muted">
-            Pairing is the recommended path. If both browsers can't be open
-            at the same time, you can use the link-based fallback below.
-          </p>
-          <SyncNotesKeyButton />
-        </div>
-      </div>
+      <NotesKeyCard />
       <ApiKeysCard />
       <PasskeysCard />
       <AccountCard />


### PR DESCRIPTION
## Summary

PR 3 of 3 for Task 68 — the consolidation pass that retires the payload-QR rendering on the AMK sync-link path and makes `/pair` the canonical browser-to-browser AMK transfer UX. PR 1 shipped the `/api/v1/auth/pair/*` endpoint family; PR 2 shipped the `/pair` route and entry points from Dashboard/Settings. This PR is client + docs only — no wire-format change, no CLI change.

- **Web:** `ShareResult` gains a `showQr` prop (default `true`, so normal one-shot secrets keep their QR). `SyncNotesKeyButton` passes `showQr={false}`. Dashboard folds `SyncNotesKeyButton` under a "More options" disclosure beneath the primary `/pair` link. Settings gets a one-line subtitle framing the sync link as the async fallback.
- **Docs:** Whitepaper's *Cross-Device Sync* section now leads with the rendezvous primitive and frames the sync link as the asynchronous fallback. New *Pair-rendezvous interception* entry in the Threat Analysis. `spec/v1/api.md § Sync secrets` adds a normative pointer to *§Web-to-Web Pairing* and a MUST NOT on rendering sync URLs as QR codes. `spec/v1/server.md` route surface now lists `GET /pair` with a cross-link to §6.4.

### Why drop QR on the sync flow

Sync URLs are bearer-equivalent to the AMK itself (one-time claim of an envelope whose plaintext is the raw 32-byte AMK). Rendering a bearer URL as a QR invites offline capture — camera shoulder-surf, projected slide, screen recording — without any UX benefit over direct copy/paste between trusted devices. The `/pair` flow's QR encodes only the public `user_code` and is provably safe (useless without a same-user session on the target account), so it stays.

### Contracts preserved

- `/api/v1/auth/pair/*` semantics unchanged (PR 1 wire is locked)
- QR encodes only `https://<host>/pair?mode=join&code=XXXX-XXXX` (PR 2 invariant, unchanged)
- Receiver-side commit-before-store still enforced in `verifyAndStoreReceivedAmk`
- 10-minute slot TTL unchanged

## Test plan

- [x] `make test-rust` — 1221 tests pass, 11 skipped
- [x] `make test-web` — 623 pass, 2 skipped
- [x] `make lint-rust` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec playwright test` — 61 pass; 9 pre-existing flakes confirmed against `git stash`-ed working tree (passkey-auth and dashboard-login redirect specs, unrelated to these changes)
- [ ] Manual: open `/dashboard` pre-AMK → no "More options" expander visible
- [ ] Manual: open `/dashboard` post-AMK → "More options" expander reveals link-only sync (no QR in modal)
- [ ] Manual: fresh CLI device-auth flow still works end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-to-browser pairing (/pair) is the primary Account Master Key sync flow.

* **Changed**
  * Sync links are no longer shown as QR codes; QR is used only for pairing.
  * Sync-related controls moved into collapsed “more options” areas and shown only when a local key exists.

* **Documentation**
  * Updated whitepaper, threat analysis, and spec to reflect the new flows and QR guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getsecrt/secrt/pull/43)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->