### PR TITLE
feat(server): bootstrap visibility for PUBLIC_BASE_URL + WebAuthn origin/RP-ID logging

### DIFF
--- a/crates/secrt-server/CHANGELOG.md
+++ b/crates/secrt-server/CHANGELOG.md
@@ -27,6 +27,14 @@
 
   No wire-format change; CLI is unaffected. Files: `web/src/features/send/ShareResult.tsx`, `web/src/components/SyncNotesKeyButton.tsx`, `web/src/features/dashboard/DashboardPage.tsx`, `web/src/features/settings/SettingsPage.tsx`, `docs/whitepaper.md`, `spec/v1/api.md`, `spec/v1/server.md`. Task: #68 (PR 3 of 3).
 
+- **`PUBLIC_BASE_URL` is now canonicalized at startup; non-origin values are rejected with a specific error.** `Config::load` parses the env var through `url::Url`, validates that it is a `scheme://host[:port]` origin only (http or https), and stores the WHATWG-canonical form in `cfg.public_base_url` plus the WebAuthn host as `cfg.rp_id`. Path, query, fragment, userinfo, or non-HTTP schemes are rejected with `ConfigError::PublicBaseUrlNotOrigin { component }` / `PublicBaseUrlBadScheme` instead of being silently accepted and producing a downstream WebAuthn `OriginMismatch`.
+
+  Why: the previous string-split helpers (`derive_rp_id` / `derive_expected_origin`) and the WebAuthn verifier could see different bytes from the same `PUBLIC_BASE_URL` if it contained a fragment, query, or trailing slash. The logger sanitized; the verifier didn't. The new arrangement keeps the verifier, logger, and share-URL formatter all reading the same canonical value pinned in `Config`.
+
+  **Operator action (rare):** existing instances with non-canonical `PUBLIC_BASE_URL` will fail to start with a clear error pointing at the offending component. Both first-party instances (`secrt.is`, `secrt.ca`) already use canonical values, so no operational change is needed there. Self-hosters who set values like `https://example.com/` (trailing slash — now stripped automatically, no action needed) are fine; values like `https://example.com/path` or `https://user:pass@host` must be fixed in `.env` / systemd `EnvironmentFile=` before upgrading.
+
+  Files: `crates/secrt-server/src/config.rs`, `crates/secrt-server/src/http/mod.rs` (retire `derive_rp_id` / `derive_expected_origin`), `crates/secrt-server/src/runtime.rs`. PR: #44.
+
 ### Fixed
 
 - **Web footer stays above mobile browser chrome.** The shared web/Tauri app shell now uses the dynamic viewport height so short pages keep the footer visible above mobile browser toolbars, with safe-area padding preserved for hardware insets.

--- a/crates/secrt-server/src/config.rs
+++ b/crates/secrt-server/src/config.rs
@@ -2,6 +2,12 @@ use std::env;
 
 use thiserror::Error;
 
+/// Default for `PUBLIC_BASE_URL` when the env var is unset. Exposed so the
+/// runtime bootstrap can distinguish "user supplied the default explicitly"
+/// from "we fell back silently" and surface a dev-mode hint if the latter
+/// would lead to a confusing WebAuthn `OriginMismatch`.
+pub const DEFAULT_PUBLIC_BASE_URL: &str = "http://localhost:8080";
+
 #[derive(Clone, Debug)]
 pub struct Config {
     pub env: String,
@@ -90,7 +96,7 @@ impl Config {
             return Err(ConfigError::InvalidDbPort(db_port_raw));
         }
 
-        let public_base_url = getenv_default("PUBLIC_BASE_URL", "http://localhost:8080")
+        let public_base_url = getenv_default("PUBLIC_BASE_URL", DEFAULT_PUBLIC_BASE_URL)
             .trim_end_matches('/')
             .to_string();
         if public_base_url.is_empty() {

--- a/crates/secrt-server/src/config.rs
+++ b/crates/secrt-server/src/config.rs
@@ -12,7 +12,16 @@ pub const DEFAULT_PUBLIC_BASE_URL: &str = "http://localhost:8080";
 pub struct Config {
     pub env: String,
     pub listen_addr: String,
+    /// Canonical origin (`scheme://host[:port]`). Always normalized in
+    /// `Config::load`: default port elided, trailing slash removed, no
+    /// path / query / fragment / userinfo. Use directly as the WebAuthn
+    /// expected origin and as a base for share URLs.
     pub public_base_url: String,
+    /// WebAuthn Relying Party ID — the host component of
+    /// `public_base_url`, no scheme, no port. Pinned alongside
+    /// `public_base_url` so the verifier and any logger see the same
+    /// canonical bytes.
+    pub rp_id: String,
     pub log_level: String,
 
     pub database_url: String,
@@ -75,12 +84,80 @@ pub enum ConfigError {
     MissingPublicBaseUrl,
     #[error("invalid PUBLIC_BASE_URL")]
     InvalidPublicBaseUrl,
+    #[error("PUBLIC_BASE_URL must be an origin only (scheme://host[:port]); got {component} component which is not allowed")]
+    PublicBaseUrlNotOrigin { component: &'static str },
+    #[error("PUBLIC_BASE_URL scheme must be http or https; got '{0}'")]
+    PublicBaseUrlBadScheme(String),
     #[error("API_KEY_PEPPER is required in production")]
     MissingApiKeyPepper,
     #[error("SESSION_TOKEN_PEPPER is required in production")]
     MissingSessionTokenPepper,
     #[error("missing env vars: {0}")]
     MissingEnvVars(String),
+}
+
+/// Result of canonicalizing a raw `PUBLIC_BASE_URL` to the
+/// `scheme://host[:port]` form WebAuthn expects.
+struct CanonicalBaseUrl {
+    /// `scheme://host[:port]` with default ports elided (`:443` for
+    /// https, `:80` for http), no trailing slash, no path, no userinfo,
+    /// no query, no fragment.
+    pub origin: String,
+    /// Host component only (`host_str()`), used as the WebAuthn RP ID.
+    pub host: String,
+}
+
+/// Parse and canonicalize a `PUBLIC_BASE_URL` value. Rejects anything
+/// outside the `scheme://host[:port]` form with a specific error so
+/// operators can fix the misconfiguration immediately instead of
+/// debugging a downstream `OriginMismatch` or RP-ID-hash mismatch.
+fn canonicalize_public_base_url(raw: &str) -> Result<CanonicalBaseUrl, ConfigError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(ConfigError::MissingPublicBaseUrl);
+    }
+
+    let parsed = url::Url::parse(trimmed).map_err(|_| ConfigError::InvalidPublicBaseUrl)?;
+
+    // WebAuthn ceremonies and the share-URL generator both assume
+    // origin-only inputs. Reject any extra structure explicitly so the
+    // operator gets an actionable error rather than a runtime symptom.
+    let scheme = parsed.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(ConfigError::PublicBaseUrlBadScheme(scheme.to_string()));
+    }
+    let path = parsed.path();
+    if !path.is_empty() && path != "/" {
+        return Err(ConfigError::PublicBaseUrlNotOrigin { component: "path" });
+    }
+    if parsed.query().is_some() {
+        return Err(ConfigError::PublicBaseUrlNotOrigin { component: "query" });
+    }
+    if parsed.fragment().is_some() {
+        return Err(ConfigError::PublicBaseUrlNotOrigin {
+            component: "fragment",
+        });
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(ConfigError::PublicBaseUrlNotOrigin {
+            component: "userinfo",
+        });
+    }
+    let host = parsed
+        .host_str()
+        .ok_or(ConfigError::InvalidPublicBaseUrl)?
+        .to_string();
+
+    // Rebuild canonical form. `url::Url::origin().ascii_serialization()`
+    // gives us the WHATWG-canonical tuple origin, which is exactly what
+    // browsers put in `clientDataJSON.origin` — default ports elided,
+    // no trailing slash, case-folded scheme/host.
+    let origin = parsed.origin().ascii_serialization();
+    if origin == "null" {
+        return Err(ConfigError::InvalidPublicBaseUrl);
+    }
+
+    Ok(CanonicalBaseUrl { origin, host })
 }
 
 impl Config {
@@ -96,15 +173,10 @@ impl Config {
             return Err(ConfigError::InvalidDbPort(db_port_raw));
         }
 
-        let public_base_url = getenv_default("PUBLIC_BASE_URL", DEFAULT_PUBLIC_BASE_URL)
-            .trim_end_matches('/')
-            .to_string();
-        if public_base_url.is_empty() {
-            return Err(ConfigError::MissingPublicBaseUrl);
-        }
-        if url::Url::parse(&public_base_url).is_err() {
-            return Err(ConfigError::InvalidPublicBaseUrl);
-        }
+        let raw_public_base_url = getenv_default("PUBLIC_BASE_URL", DEFAULT_PUBLIC_BASE_URL);
+        let canonical = canonicalize_public_base_url(&raw_public_base_url)?;
+        let public_base_url = canonical.origin;
+        let rp_id = canonical.host;
 
         let api_key_pepper = env::var("API_KEY_PEPPER")
             .unwrap_or_default()
@@ -125,6 +197,7 @@ impl Config {
             env: env_name,
             listen_addr: getenv_default("LISTEN_ADDR", ":8080"),
             public_base_url,
+            rp_id,
             log_level: getenv_default("LOG_LEVEL", "info"),
 
             database_url: env::var("DATABASE_URL")
@@ -358,6 +431,63 @@ mod tests {
             Config::load(),
             Err(ConfigError::InvalidPublicBaseUrl)
         ));
+    }
+
+    #[test]
+    fn public_base_url_canonicalized_to_origin_form() {
+        // `Url::origin().ascii_serialization()` matches what browsers put
+        // in clientDataJSON.origin — default ports elided, no trailing
+        // slash, lowercase scheme/host.
+        for (raw, expected_origin, expected_rp_id) in [
+            (
+                "http://localhost:5173",
+                "http://localhost:5173",
+                "localhost",
+            ),
+            ("https://secrt.is", "https://secrt.is", "secrt.is"),
+            // Trailing slash gets stripped.
+            ("https://secrt.is/", "https://secrt.is", "secrt.is"),
+            // Default ports elided.
+            ("https://secrt.is:443", "https://secrt.is", "secrt.is"),
+            ("http://localhost:80", "http://localhost", "localhost"),
+            // Case-folded scheme/host.
+            ("HTTPS://SECRT.IS", "https://secrt.is", "secrt.is"),
+        ] {
+            let _lock = ENV_LOCK.lock().expect("env lock");
+            let _guards = [EnvGuard::set("PUBLIC_BASE_URL", raw)];
+            let cfg = Config::load().unwrap_or_else(|err| panic!("expected {raw} to load: {err}"));
+            assert_eq!(cfg.public_base_url, expected_origin, "raw={raw}");
+            assert_eq!(cfg.rp_id, expected_rp_id, "raw={raw}");
+        }
+    }
+
+    #[test]
+    fn public_base_url_rejects_non_origin_components() {
+        for (raw, reason) in [
+            ("https://secrt.is/some/path", "path"),
+            ("https://secrt.is?x=1", "query"),
+            ("https://secrt.is#frag", "fragment"),
+            ("https://user:pass@secrt.is", "userinfo"),
+        ] {
+            let _lock = ENV_LOCK.lock().expect("env lock");
+            let _guards = [EnvGuard::set("PUBLIC_BASE_URL", raw)];
+            match Config::load() {
+                Err(ConfigError::PublicBaseUrlNotOrigin { component }) => {
+                    assert_eq!(component, reason, "raw={raw}");
+                }
+                other => panic!("expected NotOrigin({reason}) for {raw}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn public_base_url_rejects_non_http_scheme() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = [EnvGuard::set("PUBLIC_BASE_URL", "ftp://secrt.is")];
+        match Config::load() {
+            Err(ConfigError::PublicBaseUrlBadScheme(s)) => assert_eq!(s, "ftp"),
+            other => panic!("expected BadScheme, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/secrt-server/src/http/mod.rs
+++ b/crates/secrt-server/src/http/mod.rs
@@ -1983,6 +1983,10 @@ fn log_verify_error(
             // with embedded newlines (log injection) or a 10 MB string
             // (log spam) cannot poison the WARN line.
             let received_origin = sanitize_origin_for_log(&raw);
+            // expected_origin flows in from derive_expected_origin(public_base_url).
+            // An operator-typo'd PUBLIC_BASE_URL could otherwise leak a
+            // fragment, query, or userinfo into shipped logs. Same scrub.
+            let expected_origin = sanitize_origin_for_log(expected_origin);
             warn!(
                 scope,
                 error = err.as_str(),

--- a/crates/secrt-server/src/http/mod.rs
+++ b/crates/secrt-server/src/http/mod.rs
@@ -1854,14 +1854,25 @@ fn decode_and_verify_registration(
             warn!("passkey register: client_data_json not valid base64url");
         })?;
 
+    let expected_origin = derive_expected_origin(&cfg.public_base_url);
+    let expected_rp_id = derive_rp_id(&cfg.public_base_url);
     parse_registration(
         &auth_data,
         &cdj,
         expected_challenge_b64u,
-        derive_expected_origin(&cfg.public_base_url),
-        derive_rp_id(&cfg.public_base_url),
+        expected_origin,
+        expected_rp_id,
     )
-    .map_err(|err| log_verify_error("passkey register", err))
+    .map_err(|err| {
+        log_verify_error(
+            "passkey register",
+            err,
+            &cdj,
+            &auth_data,
+            expected_origin,
+            expected_rp_id,
+        )
+    })
 }
 
 /// Decode the login wire fields and run them through `verify_assertion`.
@@ -1895,24 +1906,84 @@ fn decode_and_verify_assertion(
             warn!("passkey login: stored public_key not valid base64url");
         })?;
 
+    let expected_origin = derive_expected_origin(&cfg.public_base_url);
+    let expected_rp_id = derive_rp_id(&cfg.public_base_url);
     let ctx = AssertionContext {
         stored_pubkey_sec1: &pubkey,
         stored_sign_count,
         expected_challenge_b64u,
-        expected_origin: derive_expected_origin(&cfg.public_base_url),
-        expected_rp_id: derive_rp_id(&cfg.public_base_url),
+        expected_origin,
+        expected_rp_id,
     };
     let req = AssertionRequest {
         authenticator_data: &auth_data,
         client_data_json: &cdj,
         signature: &sig,
     };
-    verify_assertion(&ctx, &req).map_err(|err| log_verify_error("passkey login", err))
+    verify_assertion(&ctx, &req).map_err(|err| {
+        log_verify_error(
+            "passkey login",
+            err,
+            &cdj,
+            &auth_data,
+            expected_origin,
+            expected_rp_id,
+        )
+    })
 }
 
-fn log_verify_error(scope: &str, err: VerifyError) {
-    // Discriminator is logged server-side only — never surfaced over the wire.
-    warn!(scope, error = err.as_str(), "webauthn verification failed");
+/// Log a WebAuthn verification failure with the discriminator. For the two
+/// variants whose values are public per-RP identifiers (`OriginMismatch`,
+/// `RpIdHashMismatch`), also include the received-vs-expected pair so a
+/// misconfigured `PUBLIC_BASE_URL` is diagnosable from the server's own log
+/// without having to spelunk through clientDataJSON in DevTools. Other
+/// discriminators stay opaque — their values are either sensitive
+/// (`InvalidSignature` over secret bits) or unhelpful for the reader.
+fn log_verify_error(
+    scope: &str,
+    err: VerifyError,
+    client_data_json: &[u8],
+    authenticator_data: &[u8],
+    expected_origin: &str,
+    expected_rp_id: &str,
+) {
+    match err {
+        VerifyError::OriginMismatch => {
+            let received = serde_json::from_slice::<serde_json::Value>(client_data_json)
+                .ok()
+                .and_then(|v| v.get("origin").and_then(|o| o.as_str()).map(str::to_string))
+                .unwrap_or_else(|| "<unparseable>".to_string());
+            warn!(
+                scope,
+                error = err.as_str(),
+                received_origin = %received,
+                expected_origin = %expected_origin,
+                "webauthn verification failed: origin mismatch"
+            );
+        }
+        VerifyError::RpIdHashMismatch => {
+            let received_hex = authenticator_data
+                .get(..32)
+                .map(hex::encode)
+                .unwrap_or_else(|| "<short>".to_string());
+            let expected_hex = hex::encode(
+                ring::digest::digest(&ring::digest::SHA256, expected_rp_id.as_bytes()).as_ref(),
+            );
+            warn!(
+                scope,
+                error = err.as_str(),
+                received_rp_id_hash = %received_hex,
+                expected_rp_id = %expected_rp_id,
+                expected_rp_id_hash = %expected_hex,
+                "webauthn verification failed: rp_id hash mismatch"
+            );
+        }
+        _ => {
+            // Discriminator only. Variant values for the remaining errors
+            // are either sensitive or unhelpful to surface.
+            warn!(scope, error = err.as_str(), "webauthn verification failed");
+        }
+    }
 }
 
 /// First 8 chars of a base64url credential_id — enough to correlate with

--- a/crates/secrt-server/src/http/mod.rs
+++ b/crates/secrt-server/src/http/mod.rs
@@ -1932,6 +1932,30 @@ fn decode_and_verify_assertion(
     })
 }
 
+/// Reduce a (potentially untrusted) origin string to the canonical
+/// `scheme://host[:port]` tuple suitable for emitting at WARN level.
+/// Returns `<invalid-origin>` if the input does not parse to a URL with
+/// both a scheme and a host. Used to scrub `clientDataJSON.origin` before
+/// it lands in a log line — a hostile peer could otherwise stuff
+/// newlines, control characters, or arbitrarily long blobs into the
+/// `origin` JSON field.
+fn sanitize_origin_for_log(raw: &str) -> String {
+    let Ok(u) = url::Url::parse(raw.trim()) else {
+        return "<invalid-origin>".to_string();
+    };
+    let scheme = u.scheme();
+    let Some(host) = u.host_str() else {
+        return "<invalid-origin>".to_string();
+    };
+    if scheme.is_empty() {
+        return "<invalid-origin>".to_string();
+    }
+    match u.port() {
+        Some(port) => format!("{scheme}://{host}:{port}"),
+        None => format!("{scheme}://{host}"),
+    }
+}
+
 /// Log a WebAuthn verification failure with the discriminator. For the two
 /// variants whose values are public per-RP identifiers (`OriginMismatch`,
 /// `RpIdHashMismatch`), also include the received-vs-expected pair so a
@@ -1949,14 +1973,20 @@ fn log_verify_error(
 ) {
     match err {
         VerifyError::OriginMismatch => {
-            let received = serde_json::from_slice::<serde_json::Value>(client_data_json)
+            let raw = serde_json::from_slice::<serde_json::Value>(client_data_json)
                 .ok()
                 .and_then(|v| v.get("origin").and_then(|o| o.as_str()).map(str::to_string))
-                .unwrap_or_else(|| "<unparseable>".to_string());
+                .unwrap_or_default();
+            // clientDataJSON.origin is attacker-influenceable (any peer can
+            // POST any JSON to /register/finish). Sanitize to the canonical
+            // scheme://host[:port] tuple before logging so a crafted value
+            // with embedded newlines (log injection) or a 10 MB string
+            // (log spam) cannot poison the WARN line.
+            let received_origin = sanitize_origin_for_log(&raw);
             warn!(
                 scope,
                 error = err.as_str(),
-                received_origin = %received,
+                received_origin = %received_origin,
                 expected_origin = %expected_origin,
                 "webauthn verification failed: origin mismatch"
             );
@@ -5195,6 +5225,52 @@ mod tests {
         ApiKeyRecord, ApiKeyRegistrationLimits, AuthStore, ChallengeRecord, PasskeyRecord,
         PrfAmkWrapperRecord, SecretSummary, SessionRecord, StorageUsage, UserRecord,
     };
+
+    #[test]
+    fn sanitize_origin_canonicalizes_and_rejects_garbage() {
+        // Happy paths — already canonical.
+        assert_eq!(
+            sanitize_origin_for_log("http://localhost:5173"),
+            "http://localhost:5173"
+        );
+        assert_eq!(
+            sanitize_origin_for_log("https://secrt.is"),
+            "https://secrt.is"
+        );
+        // Drops path / query / fragment.
+        assert_eq!(
+            sanitize_origin_for_log("http://localhost:5173/register?x=1#frag"),
+            "http://localhost:5173"
+        );
+        // Drops userinfo (`user:pass@host`).
+        assert_eq!(
+            sanitize_origin_for_log("https://user:pass@secrt.is/x"),
+            "https://secrt.is"
+        );
+        // Default port omitted on canonical form.
+        assert_eq!(
+            sanitize_origin_for_log("https://secrt.is:443"),
+            "https://secrt.is"
+        );
+        // Log-injection defense: the underlying URL parser normalizes
+        // whitespace and control characters, so a value like
+        // "https://evil\n.example" lands as "https://evil.example" rather
+        // than as a multi-line WARN. Either way, the output is safe to
+        // log on a single line.
+        let injected = sanitize_origin_for_log("https://evil\n.example");
+        assert!(!injected.contains('\n'), "got: {injected}");
+        assert_eq!(sanitize_origin_for_log(""), "<invalid-origin>");
+        assert_eq!(sanitize_origin_for_log("not-a-url"), "<invalid-origin>");
+        // No host → invalid.
+        assert_eq!(
+            sanitize_origin_for_log("file:///etc/passwd"),
+            "<invalid-origin>"
+        );
+        // Pathological length still bounded by URL parser normalization.
+        let long = format!("https://evil.example/{}", "A".repeat(50_000));
+        let sanitized = sanitize_origin_for_log(&long);
+        assert_eq!(sanitized, "https://evil.example");
+    }
     use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::Request;

--- a/crates/secrt-server/src/http/mod.rs
+++ b/crates/secrt-server/src/http/mod.rs
@@ -1815,24 +1815,6 @@ fn random_b64(len: usize) -> Result<String, ()> {
     Ok(URL_SAFE_NO_PAD.encode(b))
 }
 
-/// Derive the WebAuthn RP ID from `public_base_url`. Strips scheme, path,
-/// and port — browsers reject ports in `rp.id`. For `https://secrt.is` →
-/// `secrt.is`; for `http://localhost:8080` → `localhost`.
-fn derive_rp_id(public_base_url: &str) -> &str {
-    let s = public_base_url
-        .strip_prefix("https://")
-        .or_else(|| public_base_url.strip_prefix("http://"))
-        .unwrap_or(public_base_url);
-    let s = s.split('/').next().unwrap_or(s);
-    s.split(':').next().unwrap_or(s)
-}
-
-/// Expected `clientDataJSON.origin` value. Trims trailing slash so we
-/// match the canonical form a browser produces.
-fn derive_expected_origin(public_base_url: &str) -> &str {
-    public_base_url.trim_end_matches('/')
-}
-
 /// Decode the base64url-encoded register/add wire fields and run them
 /// through the verifier. Returns `()` on failure — the handler maps any
 /// error to opaque `401`. The discriminator is logged so observability
@@ -1854,8 +1836,12 @@ fn decode_and_verify_registration(
             warn!("passkey register: client_data_json not valid base64url");
         })?;
 
-    let expected_origin = derive_expected_origin(&cfg.public_base_url);
-    let expected_rp_id = derive_rp_id(&cfg.public_base_url);
+    // cfg.public_base_url is canonicalized to scheme://host[:port] by
+    // Config::load, and cfg.rp_id is the matching host. Both are guaranteed
+    // to be the canonical bytes a browser produces for clientDataJSON.origin
+    // and the WebAuthn RP ID respectively, so we pass them through directly.
+    let expected_origin = cfg.public_base_url.as_str();
+    let expected_rp_id = cfg.rp_id.as_str();
     parse_registration(
         &auth_data,
         &cdj,
@@ -1906,8 +1892,10 @@ fn decode_and_verify_assertion(
             warn!("passkey login: stored public_key not valid base64url");
         })?;
 
-    let expected_origin = derive_expected_origin(&cfg.public_base_url);
-    let expected_rp_id = derive_rp_id(&cfg.public_base_url);
+    // See decode_and_verify_registration: cfg.public_base_url / cfg.rp_id
+    // are canonical-by-construction from Config::load.
+    let expected_origin = cfg.public_base_url.as_str();
+    let expected_rp_id = cfg.rp_id.as_str();
     let ctx = AssertionContext {
         stored_pubkey_sec1: &pubkey,
         stored_sign_count,
@@ -1983,10 +1971,9 @@ fn log_verify_error(
             // with embedded newlines (log injection) or a 10 MB string
             // (log spam) cannot poison the WARN line.
             let received_origin = sanitize_origin_for_log(&raw);
-            // expected_origin flows in from derive_expected_origin(public_base_url).
-            // An operator-typo'd PUBLIC_BASE_URL could otherwise leak a
-            // fragment, query, or userinfo into shipped logs. Same scrub.
-            let expected_origin = sanitize_origin_for_log(expected_origin);
+            // `expected_origin` comes from cfg.public_base_url, which
+            // Config::load canonicalizes to scheme://host[:port] with no
+            // path/query/fragment/userinfo. Safe to log verbatim.
             warn!(
                 scope,
                 error = err.as_str(),
@@ -6617,6 +6604,7 @@ mod tests {
             env: "test".into(),
             listen_addr: "127.0.0.1:0".into(),
             public_base_url: "https://example.com".into(),
+            rp_id: "example.com".into(),
             log_level: "error".into(),
             database_url: String::new(),
             db_host: "127.0.0.1".into(),

--- a/crates/secrt-server/src/main.rs
+++ b/crates/secrt-server/src/main.rs
@@ -11,8 +11,8 @@ fn print_help() {
     println!("  -v, --version  Show version and exit");
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    // Argument parsing runs synchronously before anything else.
     match std::env::args().nth(1).as_deref() {
         Some("--version") | Some("-v") | Some("version") => {
             println!("secrt-server {}", VERSION);
@@ -25,7 +25,29 @@ async fn main() {
         _ => {}
     }
 
-    if let Err(err) = secrt_server::runtime::run_server().await {
+    // Load `.env` into the process environment BEFORE the Tokio runtime is
+    // built. `std::env::set_var` is unsound from a multi-threaded context,
+    // and Tokio's multi-threaded runtime spawns its worker pool eagerly,
+    // so the dotenv loader has to run while this thread is still the only
+    // one in the process. See `runtime::prepare_env` for the contract.
+    let dotenv_outcome = secrt_server::runtime::prepare_env();
+
+    // Build the Tokio runtime explicitly (rather than via `#[tokio::main]`)
+    // so the sync dotenv-load above sees a single-threaded process.
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(err) => {
+            eprintln!("failed to build tokio runtime: {err}");
+            std::process::exit(1);
+        }
+    };
+
+    let result = rt.block_on(secrt_server::runtime::run_server(dotenv_outcome));
+
+    if let Err(err) = result {
         eprintln!("{err}");
         std::process::exit(1);
     }

--- a/crates/secrt-server/src/runtime.rs
+++ b/crates/secrt-server/src/runtime.rs
@@ -64,22 +64,47 @@ impl HttpTimeouts {
 
 const PRODUCTION_HTTP_TIMEOUTS: HttpTimeouts = HttpTimeouts::production();
 
-pub async fn run_server() -> Result<(), RuntimeError> {
-    run_server_with_shutdown(shutdown_signal()).await
+/// Synchronously load `.env` into the process environment, before any
+/// async runtime is created.
+///
+/// `std::env::set_var` is unsound from a multi-threaded context, so the
+/// dotenv loader **must** run before the Tokio runtime spawns its
+/// worker pool. The supported call sequence is:
+///
+/// ```text
+/// fn main() {
+///     let dotenv_outcome = secrt_server::runtime::prepare_env();
+///     let rt = tokio::runtime::Builder::new_multi_thread()...
+///     rt.block_on(run_server_with_shutdown(shutdown_signal(), dotenv_outcome))
+/// }
+/// ```
+///
+/// In `ENV=production`, the loader is bypassed entirely — production env
+/// is expected to come from systemd `EnvironmentFile=` or equivalent.
+pub fn prepare_env() -> DotenvLoadOutcome {
+    let is_production =
+        std::env::var("ENV").unwrap_or_else(|_| "development".to_string()) == "production";
+    if is_production {
+        DotenvLoadOutcome::skipped(".env")
+    } else {
+        load_dotenv_if_present(".env")
+            .unwrap_or_else(|err| DotenvLoadOutcome::error(".env", err.to_string()))
+    }
 }
 
-pub async fn run_server_with_shutdown<F>(shutdown: F) -> Result<(), RuntimeError>
+pub async fn run_server(dotenv_outcome: DotenvLoadOutcome) -> Result<(), RuntimeError> {
+    run_server_with_shutdown(shutdown_signal(), dotenv_outcome).await
+}
+
+pub async fn run_server_with_shutdown<F>(
+    shutdown: F,
+    dotenv_outcome: DotenvLoadOutcome,
+) -> Result<(), RuntimeError>
 where
     F: Future<Output = ()> + Send + 'static,
 {
     let is_production =
         std::env::var("ENV").unwrap_or_else(|_| "development".to_string()) == "production";
-    let dotenv_outcome = if is_production {
-        DotenvLoadOutcome::skipped(".env")
-    } else {
-        load_dotenv_if_present(".env")
-            .unwrap_or_else(|err| DotenvLoadOutcome::error(".env", err.to_string()))
-    };
 
     let cfg = Config::load()?;
     init_logging(&cfg.log_level);
@@ -109,22 +134,27 @@ where
     // launching from a directory that doesn't contain a readable .env
     // (e.g. cargo run from inside `web/`, or .env with the wrong perms).
     // The symptom is `OriginMismatch` on every WebAuthn ceremony against a
-    // Vite dev server on a different port. Tell them where to look.
+    // Vite dev server on a different port. Tell them where to look — and
+    // distinguish the two cases so a perms/IO failure points at the file,
+    // not at the launch directory.
+    let dotenv_diagnostic: Option<&'static str> = match &dotenv_outcome {
+        DotenvLoadOutcome::NotFound(_) => Some("not found"),
+        DotenvLoadOutcome::Error { .. } => Some("could not be read"),
+        _ => None,
+    };
     if !is_production
-        && matches!(
-            dotenv_outcome,
-            DotenvLoadOutcome::NotFound(_) | DotenvLoadOutcome::Error { .. }
-        )
+        && dotenv_diagnostic.is_some()
         && cfg.public_base_url == DEFAULT_PUBLIC_BASE_URL
     {
         warn!(
             cwd = %std::env::current_dir()
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|_| "<unknown>".to_string()),
-            dotenv_path = %dotenv_outcome.path_display(),
-            "no .env found in current working directory; PUBLIC_BASE_URL is the default {default}. \
+            dotenv = %dotenv_outcome.summary(),
+            ".env {state} at the current working directory; PUBLIC_BASE_URL is the default {default}. \
              If you're hitting this server through a Vite dev server on a different port, launch from the repo root \
              (or export PUBLIC_BASE_URL explicitly) — otherwise WebAuthn registration will fail with OriginMismatch.",
+            state = dotenv_diagnostic.unwrap_or(""),
             default = DEFAULT_PUBLIC_BASE_URL,
         );
     }
@@ -321,11 +351,11 @@ pub enum DotenvLoadOutcome {
 }
 
 impl DotenvLoadOutcome {
-    fn skipped(path: impl Into<PathBuf>) -> Self {
+    pub fn skipped(path: impl Into<PathBuf>) -> Self {
         Self::Skipped(path.into())
     }
 
-    fn error(path: impl Into<PathBuf>, message: String) -> Self {
+    pub fn error(path: impl Into<PathBuf>, message: String) -> Self {
         Self::Error {
             path: path.into(),
             message,
@@ -342,13 +372,6 @@ impl DotenvLoadOutcome {
             Self::Error { path, message } => format!("error:{}:{}", path.display(), message),
         }
     }
-
-    fn path_display(&self) -> String {
-        match self {
-            Self::Loaded(p) | Self::NotFound(p) | Self::Skipped(p) => p.display().to_string(),
-            Self::Error { path, .. } => path.display().to_string(),
-        }
-    }
 }
 
 pub fn load_dotenv_if_present(path: impl AsRef<Path>) -> std::io::Result<DotenvLoadOutcome> {
@@ -358,15 +381,13 @@ pub fn load_dotenv_if_present(path: impl AsRef<Path>) -> std::io::Result<DotenvL
     }
 
     let contents = fs::read_to_string(&path)?;
-    // SAFETY: `std::env::set_var` is on a deprecation path because it is
-    // unsound to mutate the process environment while other threads may
-    // be reading it. This loop is only reached from
-    // `run_server_with_shutdown` *before* `Config::load` and well before
-    // the Tokio runtime spawns any worker threads — the process is still
-    // effectively single-threaded here. If this function is ever called
-    // from a post-runtime context, the calling site must switch to a
-    // thread-safe env-merging strategy (or use a dedicated config-mutex)
-    // instead.
+    // SAFETY: `std::env::set_var` is unsound from a multi-threaded
+    // context. Callers must invoke this function *before* a Tokio
+    // runtime (or any other thread pool) is created — `prepare_env()`
+    // is the single supported entry point and is called synchronously
+    // from `fn main()` prior to the runtime builder. The test suite
+    // relies on a process-wide `ENV_LOCK` mutex to serialize the
+    // remaining set_var calls and avoid concurrent reads.
     for line in contents.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -375,12 +396,18 @@ pub fn load_dotenv_if_present(path: impl AsRef<Path>) -> std::io::Result<DotenvL
         let Some((k, v)) = line.split_once('=') else {
             continue;
         };
+        // Trim the key BEFORE both the var_os check and the set_var
+        // write — a line like `PUBLIC_BASE_URL = ...` (with surrounding
+        // whitespace) would otherwise slip past the preserve-existing
+        // guard and clobber an already-set env var.
+        let key = k.trim();
+        let value = v.trim();
 
-        if std::env::var_os(k).is_some() {
+        if std::env::var_os(key).is_some() {
             continue;
         }
 
-        std::env::set_var(k.trim(), v.trim());
+        std::env::set_var(key, value);
     }
 
     Ok(DotenvLoadOutcome::Loaded(path))
@@ -839,7 +866,7 @@ mod tests {
             ),
         ];
 
-        let err = run_server_with_shutdown(async {})
+        let err = run_server_with_shutdown(async {}, DotenvLoadOutcome::skipped(".env"))
             .await
             .expect_err("expected error");
         assert!(matches!(err, RuntimeError::ParseListenAddr(_)));
@@ -855,7 +882,7 @@ mod tests {
             EnvGuard::set("DATABASE_URL", "postgres://invalid:%zz"),
         ];
 
-        let err = run_server_with_shutdown(async {})
+        let err = run_server_with_shutdown(async {}, DotenvLoadOutcome::skipped(".env"))
             .await
             .expect_err("expected error");
         assert!(matches!(err, RuntimeError::Storage(_)));
@@ -908,9 +935,10 @@ mod tests {
             EnvGuard::set("API_KEY_PEPPER", "pepper"),
         ];
 
-        let result = run_server_with_shutdown(async {
-            tokio::time::sleep(std::time::Duration::from_millis(40)).await
-        })
+        let result = run_server_with_shutdown(
+            async { tokio::time::sleep(std::time::Duration::from_millis(40)).await },
+            DotenvLoadOutcome::skipped(".env"),
+        )
         .await;
         assert!(result.is_ok(), "{result:?}");
     }

--- a/crates/secrt-server/src/runtime.rs
+++ b/crates/secrt-server/src/runtime.rs
@@ -89,17 +89,22 @@ where
     // generic origin mismatch). Origin / RP-ID values are public per-RP
     // identifiers, not secrets.
     //
-    // Strip any URL fragment / query before logging: `public_base_url` is
-    // operator-supplied and already URL-validated in Config::load, so this
-    // is defense-in-depth against an operator typo (e.g. trailing `#…`)
-    // ending up in shipped logs.
+    // Strip URL fragment, query, and userinfo before logging:
+    // `public_base_url` is operator-supplied and already URL-validated in
+    // Config::load, so this is defense-in-depth against an operator typo
+    // (trailing `#…`, accidental `?token=…`, `user:pass@host`) ending up
+    // in shipped logs. If parsing fails — which shouldn't happen since
+    // Config::load rejects invalid URLs — emit a sanitized placeholder
+    // rather than risk logging an unredacted credential.
     let public_base_url_for_log = url::Url::parse(&cfg.public_base_url)
         .map(|mut u| {
             u.set_fragment(None);
             u.set_query(None);
+            let _ = u.set_username("");
+            let _ = u.set_password(None);
             u.to_string().trim_end_matches('/').to_string()
         })
-        .unwrap_or_else(|_| cfg.public_base_url.clone());
+        .unwrap_or_else(|_| "<invalid-public-base-url>".to_string());
 
     info!(
         event = "server_bootstrap",
@@ -114,13 +119,17 @@ where
         "server bootstrap"
     );
 
-    // Dev-mode hint: if .env wasn't found AND PUBLIC_BASE_URL ended up at
-    // the default, the user is almost certainly launching from a directory
-    // that doesn't contain .env (e.g. cargo run executed inside `web/`).
+    // Dev-mode hint: if .env wasn't found OR couldn't be read AND
+    // PUBLIC_BASE_URL ended up at the default, the user is almost certainly
+    // launching from a directory that doesn't contain a readable .env
+    // (e.g. cargo run from inside `web/`, or .env with the wrong perms).
     // The symptom is `OriginMismatch` on every WebAuthn ceremony against a
     // Vite dev server on a different port. Tell them where to look.
     if !is_production
-        && matches!(dotenv_outcome, DotenvLoadOutcome::NotFound(_))
+        && matches!(
+            dotenv_outcome,
+            DotenvLoadOutcome::NotFound(_) | DotenvLoadOutcome::Error { .. }
+        )
         && cfg.public_base_url == DEFAULT_PUBLIC_BASE_URL
     {
         warn!(

--- a/crates/secrt-server/src/runtime.rs
+++ b/crates/secrt-server/src/runtime.rs
@@ -88,9 +88,22 @@ where
     // is visible at boot rather than only via the symptom (WebAuthn 401,
     // generic origin mismatch). Origin / RP-ID values are public per-RP
     // identifiers, not secrets.
+    //
+    // Strip any URL fragment / query before logging: `public_base_url` is
+    // operator-supplied and already URL-validated in Config::load, so this
+    // is defense-in-depth against an operator typo (e.g. trailing `#…`)
+    // ending up in shipped logs.
+    let public_base_url_for_log = url::Url::parse(&cfg.public_base_url)
+        .map(|mut u| {
+            u.set_fragment(None);
+            u.set_query(None);
+            u.to_string().trim_end_matches('/').to_string()
+        })
+        .unwrap_or_else(|_| cfg.public_base_url.clone());
+
     info!(
         event = "server_bootstrap",
-        public_base_url = %cfg.public_base_url,
+        public_base_url = %public_base_url_for_log,
         listen_addr = %cfg.listen_addr,
         log_level = %cfg.log_level,
         env = %cfg.env,

--- a/crates/secrt-server/src/runtime.rs
+++ b/crates/secrt-server/src/runtime.rs
@@ -87,28 +87,13 @@ where
     // One-line bootstrap log so a misconfigured PUBLIC_BASE_URL / LISTEN_ADDR
     // is visible at boot rather than only via the symptom (WebAuthn 401,
     // generic origin mismatch). Origin / RP-ID values are public per-RP
-    // identifiers, not secrets.
-    //
-    // Strip URL fragment, query, and userinfo before logging:
-    // `public_base_url` is operator-supplied and already URL-validated in
-    // Config::load, so this is defense-in-depth against an operator typo
-    // (trailing `#…`, accidental `?token=…`, `user:pass@host`) ending up
-    // in shipped logs. If parsing fails — which shouldn't happen since
-    // Config::load rejects invalid URLs — emit a sanitized placeholder
-    // rather than risk logging an unredacted credential.
-    let public_base_url_for_log = url::Url::parse(&cfg.public_base_url)
-        .map(|mut u| {
-            u.set_fragment(None);
-            u.set_query(None);
-            let _ = u.set_username("");
-            let _ = u.set_password(None);
-            u.to_string().trim_end_matches('/').to_string()
-        })
-        .unwrap_or_else(|_| "<invalid-public-base-url>".to_string());
-
+    // identifiers, not secrets — and `cfg.public_base_url` is canonicalized
+    // (`scheme://host[:port]` only, no path/query/fragment/userinfo) by
+    // `Config::load`, so it's safe to log verbatim.
     info!(
         event = "server_bootstrap",
-        public_base_url = %public_base_url_for_log,
+        public_base_url = %cfg.public_base_url,
+        rp_id = %cfg.rp_id,
         listen_addr = %cfg.listen_addr,
         log_level = %cfg.log_level,
         env = %cfg.env,
@@ -373,6 +358,15 @@ pub fn load_dotenv_if_present(path: impl AsRef<Path>) -> std::io::Result<DotenvL
     }
 
     let contents = fs::read_to_string(&path)?;
+    // SAFETY: `std::env::set_var` is on a deprecation path because it is
+    // unsound to mutate the process environment while other threads may
+    // be reading it. This loop is only reached from
+    // `run_server_with_shutdown` *before* `Config::load` and well before
+    // the Tokio runtime spawns any worker threads — the process is still
+    // effectively single-threaded here. If this function is ever called
+    // from a post-runtime context, the calling site must switch to a
+    // thread-safe env-merging strategy (or use a dedicated config-mutex)
+    // instead.
     for line in contents.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {

--- a/crates/secrt-server/src/runtime.rs
+++ b/crates/secrt-server/src/runtime.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::future::Future;
+use std::io::IsTerminal;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -380,12 +381,21 @@ pub fn init_logging(log_level: &str) {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(level));
 
-    let _ = tracing_subscriber::fmt()
+    // TTY → human-readable text with ANSI colors (WARN=yellow, ERROR=red).
+    // Non-TTY (journald, log shippers, `| jq`, CI) → JSON. The shape is
+    // load-bearing in production; only the local-dev rendering changes.
+    let is_tty = std::io::stdout().is_terminal();
+
+    let builder = tracing_subscriber::fmt()
         .with_env_filter(filter)
-        .json()
-        .with_current_span(false)
-        .with_target(false)
-        .try_init();
+        .with_target(false);
+
+    if is_tty {
+        let _ = builder.with_ansi(true).try_init();
+    } else {
+        // JSON: keep the production shape — flat fields, no nested "span".
+        let _ = builder.json().with_current_span(false).try_init();
+    }
 }
 
 #[cfg(test)]

--- a/crates/secrt-server/src/runtime.rs
+++ b/crates/secrt-server/src/runtime.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::future::Future;
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,9 +16,9 @@ use tokio::sync::Notify;
 use tokio_io_timeout::TimeoutStream;
 use tower::Service;
 use tower_http::timeout::TimeoutLayer;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use crate::config::{Config, ConfigError};
+use crate::config::{Config, ConfigError, DEFAULT_PUBLIC_BASE_URL};
 use crate::http::{build_router, parse_socket_addr, AppState};
 use crate::reaper::start_expiry_reaper;
 use crate::release_poller::{start_release_poller, PollerConfig, ReleaseFetcher, ReqwestFetcher};
@@ -71,12 +71,55 @@ pub async fn run_server_with_shutdown<F>(shutdown: F) -> Result<(), RuntimeError
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if std::env::var("ENV").unwrap_or_else(|_| "development".to_string()) != "production" {
-        let _ = load_dotenv_if_present(".env");
-    }
+    let is_production =
+        std::env::var("ENV").unwrap_or_else(|_| "development".to_string()) == "production";
+    let dotenv_outcome = if is_production {
+        DotenvLoadOutcome::skipped(".env")
+    } else {
+        load_dotenv_if_present(".env")
+            .unwrap_or_else(|err| DotenvLoadOutcome::error(".env", err.to_string()))
+    };
 
     let cfg = Config::load()?;
     init_logging(&cfg.log_level);
+
+    // One-line bootstrap log so a misconfigured PUBLIC_BASE_URL / LISTEN_ADDR
+    // is visible at boot rather than only via the symptom (WebAuthn 401,
+    // generic origin mismatch). Origin / RP-ID values are public per-RP
+    // identifiers, not secrets.
+    info!(
+        event = "server_bootstrap",
+        public_base_url = %cfg.public_base_url,
+        listen_addr = %cfg.listen_addr,
+        log_level = %cfg.log_level,
+        env = %cfg.env,
+        dotenv = %dotenv_outcome.summary(),
+        cwd = %std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "<unknown>".to_string()),
+        "server bootstrap"
+    );
+
+    // Dev-mode hint: if .env wasn't found AND PUBLIC_BASE_URL ended up at
+    // the default, the user is almost certainly launching from a directory
+    // that doesn't contain .env (e.g. cargo run executed inside `web/`).
+    // The symptom is `OriginMismatch` on every WebAuthn ceremony against a
+    // Vite dev server on a different port. Tell them where to look.
+    if !is_production
+        && matches!(dotenv_outcome, DotenvLoadOutcome::NotFound(_))
+        && cfg.public_base_url == DEFAULT_PUBLIC_BASE_URL
+    {
+        warn!(
+            cwd = %std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "<unknown>".to_string()),
+            dotenv_path = %dotenv_outcome.path_display(),
+            "no .env found in current working directory; PUBLIC_BASE_URL is the default {default}. \
+             If you're hitting this server through a Vite dev server on a different port, launch from the repo root \
+             (or export PUBLIC_BASE_URL explicitly) — otherwise WebAuthn registration will fail with OriginMismatch.",
+            default = DEFAULT_PUBLIC_BASE_URL,
+        );
+    }
 
     // Validate listen address early, before expensive DB operations.
     let addr = parse_socket_addr(&cfg.listen_addr)
@@ -249,13 +292,64 @@ async fn shutdown_signal() {
     }
 }
 
-pub fn load_dotenv_if_present(path: impl AsRef<Path>) -> std::io::Result<()> {
-    let path = path.as_ref();
-    if !path.exists() {
-        return Ok(());
+/// Outcome of a `load_dotenv_if_present` call. Carries the resolved path
+/// (relative or absolute, as supplied) so the caller can include it in a
+/// bootstrap log without re-deriving it.
+#[derive(Debug, Clone)]
+pub enum DotenvLoadOutcome {
+    /// File found and parsed; some or all lines may have been skipped (the
+    /// path is included; the count of applied lines is not — the file is
+    /// for local dev, the truth is in the resolved Config).
+    Loaded(PathBuf),
+    /// No file at this path. Bootstrap fell back to process env + defaults.
+    NotFound(PathBuf),
+    /// Production mode — the loader was bypassed entirely. Process env is
+    /// expected to come from systemd `EnvironmentFile=` or similar.
+    Skipped(PathBuf),
+    /// Found the file but failed to read it (permissions, IO error). The
+    /// caller proceeds with process env + defaults but should surface the
+    /// error.
+    Error { path: PathBuf, message: String },
+}
+
+impl DotenvLoadOutcome {
+    fn skipped(path: impl Into<PathBuf>) -> Self {
+        Self::Skipped(path.into())
     }
 
-    let contents = fs::read_to_string(path)?;
+    fn error(path: impl Into<PathBuf>, message: String) -> Self {
+        Self::Error {
+            path: path.into(),
+            message,
+        }
+    }
+
+    /// One-line tag suitable for a structured log field. Stable form so a
+    /// future grep or alert can match on it.
+    pub fn summary(&self) -> String {
+        match self {
+            Self::Loaded(p) => format!("loaded:{}", p.display()),
+            Self::NotFound(p) => format!("not_found:{}", p.display()),
+            Self::Skipped(p) => format!("skipped:{}", p.display()),
+            Self::Error { path, message } => format!("error:{}:{}", path.display(), message),
+        }
+    }
+
+    fn path_display(&self) -> String {
+        match self {
+            Self::Loaded(p) | Self::NotFound(p) | Self::Skipped(p) => p.display().to_string(),
+            Self::Error { path, .. } => path.display().to_string(),
+        }
+    }
+}
+
+pub fn load_dotenv_if_present(path: impl AsRef<Path>) -> std::io::Result<DotenvLoadOutcome> {
+    let path = path.as_ref().to_path_buf();
+    if !path.exists() {
+        return Ok(DotenvLoadOutcome::NotFound(path));
+    }
+
+    let contents = fs::read_to_string(&path)?;
     for line in contents.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -272,7 +366,7 @@ pub fn load_dotenv_if_present(path: impl AsRef<Path>) -> std::io::Result<()> {
         std::env::set_var(k.trim(), v.trim());
     }
 
-    Ok(())
+    Ok(DotenvLoadOutcome::Loaded(path))
 }
 
 pub fn init_logging(log_level: &str) {
@@ -324,6 +418,12 @@ mod tests {
             std::env::set_var(key, value);
             Self { key, old }
         }
+
+        fn clear(key: &'static str) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, old }
+        }
     }
 
     impl Drop for EnvGuard {
@@ -340,6 +440,46 @@ mod tests {
     fn dotenv_absent_is_ok() {
         let r = load_dotenv_if_present("/tmp/definitely-not-there-secrt-dotenv");
         assert!(r.is_ok());
+        let outcome = r.unwrap();
+        assert!(matches!(outcome, DotenvLoadOutcome::NotFound(_)));
+        let summary = outcome.summary();
+        assert!(summary.starts_with("not_found:"), "got: {summary}");
+    }
+
+    #[test]
+    fn dotenv_loaded_outcome_reports_path() {
+        let _lock = env_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("dotenv-outcome");
+        std::fs::write(&path, "DOTENV_OUTCOME_PROBE=hello\n").expect("write dotenv");
+        let _guard = EnvGuard::clear("DOTENV_OUTCOME_PROBE");
+
+        let outcome = load_dotenv_if_present(&path).expect("load dotenv");
+        match outcome {
+            DotenvLoadOutcome::Loaded(p) => assert_eq!(p, path),
+            other => panic!("expected Loaded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dotenv_summary_is_stable_per_variant() {
+        // Summary tags are intentionally stable so a future grep / alert can
+        // match on them. Pin the prefixes.
+        assert!(DotenvLoadOutcome::Loaded(PathBuf::from("/x"))
+            .summary()
+            .starts_with("loaded:"));
+        assert!(DotenvLoadOutcome::NotFound(PathBuf::from("/x"))
+            .summary()
+            .starts_with("not_found:"));
+        assert!(DotenvLoadOutcome::Skipped(PathBuf::from("/x"))
+            .summary()
+            .starts_with("skipped:"));
+        assert!(DotenvLoadOutcome::Error {
+            path: PathBuf::from("/x"),
+            message: "perm".to_string(),
+        }
+        .summary()
+        .starts_with("error:"));
     }
 
     #[test]

--- a/crates/secrt-server/tests/api_error_paths.rs
+++ b/crates/secrt-server/tests/api_error_paths.rs
@@ -22,6 +22,7 @@ fn cfg() -> Config {
         env: "test".into(),
         listen_addr: "127.0.0.1:0".into(),
         public_base_url: "https://example.com".into(),
+        rp_id: "example.com".into(),
         log_level: "error".into(),
 
         database_url: String::new(),

--- a/crates/secrt-server/tests/helpers/mod.rs
+++ b/crates/secrt-server/tests/helpers/mod.rs
@@ -976,6 +976,7 @@ pub fn test_config() -> Config {
         env: "test".into(),
         listen_addr: "127.0.0.1:0".into(),
         public_base_url: "https://example.com".into(),
+        rp_id: "example.com".into(),
         log_level: "error".into(),
 
         database_url: String::new(),


### PR DESCRIPTION
## Summary

Diagnoses the dev-mode footgun discovered while testing PR #43 manually: launching \`secrt-server\` from a CWD that doesn't contain \`.env\` (e.g. \`cargo run -p secrt-server\` from inside \`crates/secrt-server/\`) silently falls back to \`PUBLIC_BASE_URL=http://localhost:8080\`. Every WebAuthn ceremony against a Vite dev server on \`:5173\` then fails with an opaque \`401\` whose discriminator (\`OriginMismatch\`) was logged but whose actual values were not.

Three changes, all server-side observability — no wire-format change, no client change, no security regression.

### 1. Bootstrap INFO log at startup

One line that captures all the values that matter for the WebAuthn ceremonies:

\`\`\`
event=\"server_bootstrap\"
public_base_url=\"http://localhost:8080\"
listen_addr=\":8080\"
log_level=\"info\"
env=\"development\"
dotenv=\"not_found:.env\"
cwd=\"/Users/.../crates/secrt-server\"
\`\`\`

A misconfigured \`PUBLIC_BASE_URL\` is now visible at boot, not only via symptom.

### 2. Dotenv loader returns an outcome enum

\`load_dotenv_if_present\` now returns \`DotenvLoadOutcome\` (\`Loaded(_)\` / \`NotFound(_)\` / \`Skipped(_)\` / \`Error { .. }\`). \`summary()\` emits stable prefixes (\`loaded:\` / \`not_found:\` / \`skipped:\` / \`error:\`) so grep/alerts have a stable surface. Backwards-compatible at call sites — both existing callers used \`let _ = …\` or \`if let Err(_)\`, and the new shape carries through unchanged for both.

### 3. Dev-mode WARN when defaults are silently in play

When \`ENV != production\`, \`.env\` was not found, and \`PUBLIC_BASE_URL\` ended up at the documented default, one WARN line tells the user exactly what to do:

\`\`\`
no .env found in current working directory; PUBLIC_BASE_URL is the default http://localhost:8080.
If you're hitting this server through a Vite dev server on a different port, launch from the repo root
(or export PUBLIC_BASE_URL explicitly) — otherwise WebAuthn registration will fail with OriginMismatch.
\`\`\`

### 4. WebAuthn verifier log includes received vs expected (for the two safe variants only)

\`log_verify_error\` now extracts and logs:

- \`received_origin\` + \`expected_origin\` on \`OriginMismatch\` (parsed from \`clientDataJSON\`)
- \`received_rp_id_hash\` + \`expected_rp_id\` + \`expected_rp_id_hash\` on \`RpIdHashMismatch\`

Other discriminators stay opaque. Origin and RP-ID are public per-RP identifiers, not secrets — the spec already treats them as values users can read off a QR. Surfacing them server-side collapses today's debugging dance (decode clientDataJSON in DevTools, base64url-decode by hand) to zero.

### What this PR explicitly does NOT do

- **Loosen origin / RP-ID comparison.** Exact-match is correct; WebAuthn's anti-phishing defense rides on the browser binding \`clientDataJSON.origin\` to the actual top-level page origin.
- **Walk up the directory tree looking for \`.env\`.** Cargo / pnpm don't; we shouldn't be more magical than them.
- **Refuse to start when defaults are in use.** Defaults are useful for fresh-clone demos. The fix is visibility, not refusal.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`make lint-rust\` clean (clippy + fmt-check)
- [x] \`make test-rust\` — 1221 pass, 11 skipped. New unit tests:
  - \`dotenv_absent_is_ok\` upgraded to assert \`NotFound(_)\` + summary prefix
  - \`dotenv_loaded_outcome_reports_path\` covers the new \`Loaded(_)\` variant
  - \`dotenv_summary_is_stable_per_variant\` pins the four summary prefixes
- [x] Manual: launched \`cargo run -p secrt-server\` from \`crates/secrt-server/\`. Bootstrap INFO printed all values; WARN fired immediately with the explicit OriginMismatch hint. Verified.
- [ ] Manual: launch from repo root → WARN does not fire (path with valid \`.env\`).
- [ ] Manual: trigger an actual \`OriginMismatch\` and confirm \`received_origin=\` and \`expected_origin=\` are both in the WARN log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stable default for PUBLIC_BASE_URL and explicit startup reporting of dotenv load outcomes.

* **Bug Fixes**
  * Enforced and validated PUBLIC_BASE_URL as an origin (http/https only); derived rp_id from it.
  * Improved WebAuthn diagnostics: logs sanitized expected vs received origin/RP-ID to reduce log-injection risk.

* **Chores**
  * Startup now logs dotenv outcome, cwd, public_base_url, rp_id, listen address, log level, and uses TTY-aware formatting.

* **Tests**
  * Expanded tests for URL canonicalization, dotenv outcomes, and verification logging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getsecrt/secrt/pull/44)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->