### PR TITLE
chore(server): bump version to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrt-cli"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "secrt-core"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "secrt-desktop"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "secrt-server"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.7"
+version = "0.18.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/getsecrt/secrt"

--- a/crates/secrt-cli/Cargo.toml
+++ b/crates/secrt-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "secrt"
 path = "src/main.rs"
 
 [dependencies]
-secrt-core = { path = "../secrt-core", version = "0.17.7" }
+secrt-core = { path = "../secrt-core", version = "0.18.0" }
 ring.workspace = true
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 serde.workspace = true

--- a/crates/secrt-desktop/Cargo.toml
+++ b/crates/secrt-desktop/Cargo.toml
@@ -15,7 +15,7 @@ name = "secrt_desktop"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
-secrt-core = { path = "../secrt-core", version = "0.17.4" }
+secrt-core = { path = "../secrt-core", version = "0.18.0" }
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 keyring = "3"

--- a/crates/secrt-server/CHANGELOG.md
+++ b/crates/secrt-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.18.0 — 2026-05-10
 
 ### Added
 

--- a/crates/secrt-server/Cargo.toml
+++ b/crates/secrt-server/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.82"
 description = "Axum backend and admin tooling for secrt"
 
 [dependencies]
-secrt-core = { path = "../secrt-core", version = "0.17.7" }
+secrt-core = { path = "../secrt-core", version = "0.18.0" }
 ring.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -471,7 +471,7 @@ mkdir -p /opt/secrt/bin
 # Set architecture (change to arm64 if needed)
 ARCH=amd64
 # Use the latest server release tag (check https://github.com/getsecrt/secrt/releases?q=server)
-VERSION="server/v0.17.7"
+VERSION="server/v0.18.0"
 
 cd /tmp
 gh release download "$VERSION" --repo getsecrt/secrt \
@@ -490,7 +490,7 @@ rm secrt-server-checksums-sha256.txt
 ```
 
 > **Note:** If `gh` is not installed, you can download directly:
-> `curl -fsSL -o /tmp/secrt-server-linux-${ARCH} "https://github.com/getsecrt/secrt/releases/download/server%2Fv0.17.7/secrt-server-linux-${ARCH}"`
+> `curl -fsSL -o /tmp/secrt-server-linux-${ARCH} "https://github.com/getsecrt/secrt/releases/download/server%2Fv0.18.0/secrt-server-linux-${ARCH}"`
 
 ### 7.2 Environment config
 


### PR DESCRIPTION
Release prep for **server/v0.18.0**.

## Scope

Server-only release. \`crates/secrt-cli/CHANGELOG.md\` \`## Unreleased\` is empty — no \`cli/v0.18.0\` tag will follow this.

## Changes

- Workspace version 0.17.7 → 0.18.0
- \`secrt-core\` dep version bumped in lockstep in \`secrt-cli\`, \`secrt-server\`, \`secrt-desktop\` Cargo.tomls
- \`crates/secrt-server/CHANGELOG.md\`: \`## Unreleased\` → \`## 0.18.0 — 2026-05-10\`
- \`docs/self-hosting.md\`: \`VERSION=\"server/v0.18.0\"\` (line 474) + curl download URL pin (line 493)

## Release contents (see CHANGELOG)

- **Added:** \`/api/v1/auth/pair/*\` endpoint family — browser-to-browser AMK transfer
- **Changed:** Payload-QR retired on AMK sync path; \`/pair\` is the canonical AMK transfer UX
- **Changed:** \`PUBLIC_BASE_URL\` canonicalized at startup; non-origin values rejected with a clear error. Both first-party instances (\`secrt.is\`, \`secrt.ca\`) already canonical — no operator action needed. Self-hosters with \`path\`/\`query\`/\`fragment\`/\`userinfo\` in the env var will fail-fast on upgrade and need to fix the value.
- **Changed:** Bootstrap-visibility log + dev-mode hint when \`.env\` isn't found and \`PUBLIC_BASE_URL\` falls to default
- **Changed:** WebAuthn verify-failure logs now include received-vs-expected for \`OriginMismatch\` and \`RpIdHashMismatch\`
- **Fixed:** Mobile browser-chrome footer

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`make lint-rust\` clean (clippy + fmt-check)
- [x] \`make test-rust\` — 1227 pass, 11 skipped
- [x] No CLI \`Unreleased\` entries (CLI didn't change since 0.17.7)
- [ ] After merge: tag \`server/v0.18.0\` with \`git-tag-sk -m \"secrt-server 0.18.0\" server/v0.18.0\` (YubiKey PIN + touch)
- [ ] After push: GitHub Actions \`release-server.yml\` builds binaries and publishes release with CHANGELOG body
- [ ] Deploy: \`ssh secrt.is secrt-server-deploy && ssh secrt.ca secrt-server-deploy\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.18.0

* **Documentation**
  * Updated installation and upgrade instructions to reference the latest release version

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getsecrt/secrt/pull/45)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->