### PR TITLE
chore(ci): nest CodeRabbit tools block under reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -136,46 +136,48 @@ reviews:
     unit_tests:
       enabled: false
 
-tools:
-  # Secret scanning — always on for a credential-handling project
-  gitleaks:
-    enabled: true
-  trufflehog:
-    enabled: true
+  # Per-tool toggles must be nested under `reviews:` — top-level `tools:`
+  # is silently ignored by CodeRabbit's current schema.
+  tools:
+    # Secret scanning — always on for a credential-handling project
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
 
-  # Code security analysis
-  semgrep:
-    enabled: true
-  opengrep:
-    enabled: true
+    # Code security analysis
+    semgrep:
+      enabled: true
+    opengrep:
+      enabled: true
 
-  # Rust
-  # (CodeRabbit reads `cargo clippy` output via github-checks if your CI runs it)
+    # Rust
+    # (CodeRabbit reads `cargo clippy` output via github-checks if your CI runs it)
 
-  # JS/TS (web frontend)
-  eslint:
-    enabled: true
-  biome:
-    enabled: true
+    # JS/TS (web frontend)
+    eslint:
+      enabled: true
+    biome:
+      enabled: true
 
-  # Shell scripts (scripts/)
-  shellcheck:
-    enabled: true
+    # Shell scripts (scripts/)
+    shellcheck:
+      enabled: true
 
-  # YAML / GitHub Actions
-  actionlint:
-    enabled: true
-  yamllint:
-    enabled: true
+    # YAML / GitHub Actions
+    actionlint:
+      enabled: true
+    yamllint:
+      enabled: true
 
-  # Markdown
-  markdownlint:
-    enabled: true
+    # Markdown
+    markdownlint:
+      enabled: true
 
-  # CI integration — pull failing job logs into the review context
-  github-checks:
-    enabled: true
-    timeout_ms: 90000
+    # CI integration — pull failing job logs into the review context
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
 
 chat:
   art: false


### PR DESCRIPTION
## Summary

Top-level \`tools:\` in \`.coderabbit.yaml\` was silently ignored by CodeRabbit's current schema. Every CodeRabbit review on PR #43 and #44 surfaced this as a parse warning:

> Validation error: Unrecognized key(s) in object: 'tools'

All ten tool toggles (gitleaks, trufflehog, semgrep, opengrep, eslint, biome, shellcheck, actionlint, yamllint, markdownlint, github-checks) were running on CodeRabbit's defaults rather than the explicit values configured here.

Pure indentation fix — the \`tools:\` block is now nested under \`reviews:\` per CodeRabbit's documented schema. No functional changes to the toggle values themselves.

## Test plan

- [x] CodeRabbit's auto-review of this PR should run without the "Unrecognized key" warning.
- [x] Walkthrough should reflect the now-active tool toggles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration structure to align with current schema requirements. No functional changes to enabled tools or behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getsecrt/secrt/pull/46)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->