### PR TITLE
feat(server): dedicated rate limiter for /auth/pair/* endpoints

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -109,6 +109,29 @@ reviews:
         Documentation: focus on accuracy of security claims and user-facing crypto guidance.
         Do not nitpick prose style. Flag any technical claim that contradicts the code.
 
+    - path: "**/CHANGELOG.md"
+      instructions: |
+        Changelog entries follow the project schema documented in AGENTS.md
+        § "Versioning & changelog" — NOT vanilla Keep a Changelog. Key
+        differences for review:
+
+        - Trailing references (`Spec:`, `Files:`, `Issue:`, `PR:`, `Task:`)
+          are OPTIONAL. Include only those that apply. Operator-side
+          runtime-config changes (rate limits, env-var tuning, dotenv
+          loaders) typically have no Spec link. Work originating from
+          in-session discussion has no Issue/Task link. Do NOT flag a
+          missing optional reference as a "required schema" violation.
+
+        - Headline = one bolded sentence, ≤20 words, period-terminated.
+          Use Keep a Changelog category headings (`Added` / `Changed` /
+          `Fixed` / `Security` / `Deprecated` / `Removed`).
+
+        - Indented paragraph body for the WHY; sub-bullets for related
+          details; references on a separate trailing line.
+
+        Flag content accuracy (does the entry contradict the code?), not
+        schema-shape preferences.
+
     - path: ".github/workflows/**"
       instructions: |
         CI workflows. Review for:

--- a/.env.example
+++ b/.env.example
@@ -140,3 +140,23 @@ APIKEY_REGISTER_IP_MAX_PER_HOUR=5
 # Hard cap per client IP in a rolling 24-hour window.
 # Default: 20
 APIKEY_REGISTER_IP_MAX_PER_DAY=20
+
+# ---------------------------------------------------------------------------
+# Web-to-Web Pairing rate limits
+# ---------------------------------------------------------------------------
+# Per-IP gate shared across all six `/auth/pair/*` endpoints (start, poll,
+# claim, challenge, approve, cancel). Sized for the realistic UX: a single
+# pair flow makes ~15 calls in a tight cluster (start + claim + several
+# polls + challenge + approve + cancel), and the receiver polls every few
+# hundred ms while waiting for the sender to approve.
+#
+# Token-bucket rate (requests per second sustained).
+# Default: 2.0
+WEB_PAIR_RATE=2.0
+# Token-bucket burst size.
+# Default: 30
+WEB_PAIR_BURST=30
+#
+# For local dev / rapid manual testing, you can crank these effectively-off:
+#   WEB_PAIR_RATE=100
+#   WEB_PAIR_BURST=1000

--- a/crates/secrt-server/CHANGELOG.md
+++ b/crates/secrt-server/CHANGELOG.md
@@ -18,11 +18,17 @@
 
 ### Changed
 
-- **Dedicated rate limiter for `/auth/pair/*`; defaults sized for a real pair UX.** All six pair endpoints (`/start`, `/poll`, `/claim`, `/challenge`, `/approve`, `/cancel`) previously shared `apikey_register_limiter` (default `0.5 rps, burst 6`), which is tuned for once-a-day API-key minting. Because the receiver's UI polls every few hundred milliseconds while waiting on the sender to approve, an honest pair flow burned the burst in seconds and produced spurious `429`s.
+- **`/auth/pair/*` endpoints get their own rate-limit budget, no longer sharing the API-key-mint limiter.**
 
-  New `WEB_PAIR_RATE` (default `2.0`) and `WEB_PAIR_BURST` (default `30`) tunables drive a new `web_pair_limiter`. Sized for one full round trip in a tight cluster (~15 ops) plus continuous polling at 500 ms cadence; still bounds slot-creation abuse. For rapid manual testing, dev `.env` can set `WEB_PAIR_RATE=100` / `WEB_PAIR_BURST=1000` to take the limiter effectively out of the loop.
+  The previous shared budget (`apikey_register_limiter`, default `0.5 rps, burst 6`) was sized for once-a-day API-key minting and produced spurious `429`s during real pair UX, because the receiver polls every few hundred milliseconds while waiting on the sender to approve.
 
-  Files: `crates/secrt-server/src/config.rs`, `crates/secrt-server/src/http/mod.rs` (six pair handlers switch from `apikey_register_limiter` to `web_pair_limiter`), `.env.example`. The `test_config_high_pair_rate` helper in `crates/secrt-server/tests/web_pair.rs` is retired — `test_config()` now provides web-pair limits high enough for the suite.
+  - New `web_pair_limiter` covers all six pair handlers (`/start`, `/poll`, `/claim`, `/challenge`, `/approve`, `/cancel`).
+  - Tunable via `WEB_PAIR_RATE` (default `2.0` rps) and `WEB_PAIR_BURST` (default `30`). Sized for one round trip in a tight cluster (~15 ops) plus continuous polling at 500 ms cadence; still bounds slot-creation abuse.
+  - Invalid env values (non-positive rate, non-finite rate, zero burst) silently clamp to the documented defaults rather than fail-fast — these are dev tunables, not security-load-bearing.
+  - For local dev, `WEB_PAIR_RATE=100` / `WEB_PAIR_BURST=1000` effectively disables the limiter for rapid manual testing.
+  - The `test_config_high_pair_rate` workaround helper in `crates/secrt-server/tests/web_pair.rs` is retired — `test_config()` now provides web-pair limits high enough for the suite.
+
+  Files: `crates/secrt-server/src/config.rs`, `crates/secrt-server/src/http/mod.rs`, `crates/secrt-server/tests/web_pair.rs`, `.env.example`. PR: #47.
 
 - **Payload-QR retired on the AMK sync path; `/pair` is now the canonical browser-to-browser AMK transfer UX.** The link-based sync transport (`SyncNotesKeyButton` + `/sync/{id}#<urlKey>`) remains available as an asynchronous fallback for cases where both browsers cannot be open simultaneously, but the source-browser UI no longer renders the sync URL as a QR code.
 

--- a/crates/secrt-server/CHANGELOG.md
+++ b/crates/secrt-server/CHANGELOG.md
@@ -18,6 +18,12 @@
 
 ### Changed
 
+- **Dedicated rate limiter for `/auth/pair/*`; defaults sized for a real pair UX.** All six pair endpoints (`/start`, `/poll`, `/claim`, `/challenge`, `/approve`, `/cancel`) previously shared `apikey_register_limiter` (default `0.5 rps, burst 6`), which is tuned for once-a-day API-key minting. Because the receiver's UI polls every few hundred milliseconds while waiting on the sender to approve, an honest pair flow burned the burst in seconds and produced spurious `429`s.
+
+  New `WEB_PAIR_RATE` (default `2.0`) and `WEB_PAIR_BURST` (default `30`) tunables drive a new `web_pair_limiter`. Sized for one full round trip in a tight cluster (~15 ops) plus continuous polling at 500 ms cadence; still bounds slot-creation abuse. For rapid manual testing, dev `.env` can set `WEB_PAIR_RATE=100` / `WEB_PAIR_BURST=1000` to take the limiter effectively out of the loop.
+
+  Files: `crates/secrt-server/src/config.rs`, `crates/secrt-server/src/http/mod.rs` (six pair handlers switch from `apikey_register_limiter` to `web_pair_limiter`), `.env.example`. The `test_config_high_pair_rate` helper in `crates/secrt-server/tests/web_pair.rs` is retired — `test_config()` now provides web-pair limits high enough for the suite.
+
 - **Payload-QR retired on the AMK sync path; `/pair` is now the canonical browser-to-browser AMK transfer UX.** The link-based sync transport (`SyncNotesKeyButton` + `/sync/{id}#<urlKey>`) remains available as an asynchronous fallback for cases where both browsers cannot be open simultaneously, but the source-browser UI no longer renders the sync URL as a QR code.
 
   Why: sync URLs are bearer-equivalent to the AMK itself. Rendering a bearer URL as a QR invites offline capture (camera shoulder-surf, projected slide, screen recording) without giving any UX win over direct copy/paste between trusted devices. The Web-to-Web Pairing flow keeps wrapping material entirely on user devices and binds the rendezvous slot to a single `user_id`, so the QR it does render is provably safe (encodes only the public `user_code`, useless without a same-user session).

--- a/crates/secrt-server/src/config.rs
+++ b/crates/secrt-server/src/config.rs
@@ -63,6 +63,15 @@ pub struct Config {
     pub passkey_ceremony_rate: f64,
     pub passkey_ceremony_burst: usize,
 
+    /// Per-IP rate limit shared across the six `/auth/pair/*` endpoints
+    /// (start, poll, claim, challenge, approve, cancel). Tuned to absorb a
+    /// realistic browser-to-browser pair UX — `/poll` alone is called every
+    /// few seconds while a slot is open — without becoming a slot-flooding
+    /// vector. Burst should comfortably cover one full pair round trip
+    /// (~15 ops); sustained rate should cover continuous polling.
+    pub web_pair_rate: f64,
+    pub web_pair_burst: usize,
+
     /// Feature flags
     pub encrypted_notes_enabled: bool,
 
@@ -255,6 +264,14 @@ impl Config {
             // challenges-table fill attack uneconomical.
             passkey_ceremony_rate: getenv_f64_default("PASSKEY_CEREMONY_RATE", 0.5),
             passkey_ceremony_burst: getenv_usize_default("PASSKEY_CEREMONY_BURST", 6),
+
+            // Pair endpoints are session-authenticated and rely on /poll
+            // every few seconds while a slot is open. 2 rps + burst 30
+            // accommodates one round trip (~15 ops in a tight cluster) and
+            // continuous polling at ~500ms cadence indefinitely, while
+            // still bounding slot-creation abuse.
+            web_pair_rate: getenv_f64_default("WEB_PAIR_RATE", 2.0),
+            web_pair_burst: getenv_usize_default("WEB_PAIR_BURST", 30),
 
             encrypted_notes_enabled: getenv_bool_default("ENCRYPTED_NOTES_ENABLED", true),
 

--- a/crates/secrt-server/src/config.rs
+++ b/crates/secrt-server/src/config.rs
@@ -202,6 +202,23 @@ impl Config {
             return Err(ConfigError::MissingSessionTokenPepper);
         }
 
+        // Web-pair limiter sanity check. A bucket configured with rate <= 0,
+        // non-finite, or burst == 0 would silently deny every request and
+        // make the pair flow look like a server outage. Clamp to the
+        // documented defaults rather than fail-fast — the env vars are
+        // dev-tunables, not security-load-bearing, and the right failure
+        // mode for "operator typo'd a knob" is "fall back to known good".
+        const WEB_PAIR_RATE_DEFAULT: f64 = 2.0;
+        const WEB_PAIR_BURST_DEFAULT: usize = 30;
+        let mut web_pair_rate = getenv_f64_default("WEB_PAIR_RATE", WEB_PAIR_RATE_DEFAULT);
+        if !web_pair_rate.is_finite() || web_pair_rate <= 0.0 {
+            web_pair_rate = WEB_PAIR_RATE_DEFAULT;
+        }
+        let mut web_pair_burst = getenv_usize_default("WEB_PAIR_BURST", WEB_PAIR_BURST_DEFAULT);
+        if web_pair_burst == 0 {
+            web_pair_burst = WEB_PAIR_BURST_DEFAULT;
+        }
+
         Ok(Self {
             env: env_name,
             listen_addr: getenv_default("LISTEN_ADDR", ":8080"),
@@ -269,9 +286,10 @@ impl Config {
             // every few seconds while a slot is open. 2 rps + burst 30
             // accommodates one round trip (~15 ops in a tight cluster) and
             // continuous polling at ~500ms cadence indefinitely, while
-            // still bounding slot-creation abuse.
-            web_pair_rate: getenv_f64_default("WEB_PAIR_RATE", 2.0),
-            web_pair_burst: getenv_usize_default("WEB_PAIR_BURST", 30),
+            // still bounding slot-creation abuse. Values are clamped to
+            // sane defaults above if the env var is non-positive or 0.
+            web_pair_rate,
+            web_pair_burst,
 
             encrypted_notes_enabled: getenv_bool_default("ENCRYPTED_NOTES_ENABLED", true),
 
@@ -505,6 +523,44 @@ mod tests {
             Err(ConfigError::PublicBaseUrlBadScheme(s)) => assert_eq!(s, "ftp"),
             other => panic!("expected BadScheme, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn web_pair_clamps_invalid_values_to_defaults() {
+        // Each row is a bad env var that should be silently clamped to the
+        // documented default (rate 2.0 / burst 30). The point: a fat-fingered
+        // .env should not silently jam the pair flow — the limiter must keep
+        // serving legitimate traffic.
+        for (rate, burst) in [
+            ("0", "0"),   // zeros
+            ("-1", "0"),  // negative rate
+            ("nan", "0"), // non-finite rate
+            ("inf", "0"), // infinite rate
+        ] {
+            let _lock = ENV_LOCK.lock().expect("env lock");
+            let _guards = [
+                EnvGuard::set("WEB_PAIR_RATE", rate),
+                EnvGuard::set("WEB_PAIR_BURST", burst),
+            ];
+            let cfg = Config::load().expect("load");
+            assert_eq!(
+                (cfg.web_pair_rate, cfg.web_pair_burst),
+                (2.0, 30),
+                "rate={rate} burst={burst}"
+            );
+        }
+    }
+
+    #[test]
+    fn web_pair_passes_through_valid_values() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guards = [
+            EnvGuard::set("WEB_PAIR_RATE", "50"),
+            EnvGuard::set("WEB_PAIR_BURST", "500"),
+        ];
+        let cfg = Config::load().expect("load");
+        assert_eq!(cfg.web_pair_rate, 50.0);
+        assert_eq!(cfg.web_pair_burst, 500);
     }
 
     #[test]

--- a/crates/secrt-server/src/http/mod.rs
+++ b/crates/secrt-server/src/http/mod.rs
@@ -63,6 +63,11 @@ pub struct AppState {
     /// Each /start call inserts a `webauthn_challenges` row with a 10-minute
     /// TTL — without this limiter, an attacker can spam-fill that table.
     pub passkey_ceremony_limiter: Limiter,
+    /// Per-IP gate for `/auth/pair/*` endpoints. Separated from
+    /// `apikey_register_limiter` so that the `/poll` cadence inherent to
+    /// the pair flow doesn't burn the API-key-mint budget on legitimate
+    /// UX. Tuned via `WEB_PAIR_RATE` / `WEB_PAIR_BURST` (see Config).
+    pub web_pair_limiter: Limiter,
     pub owner_hasher: OwnerHasher,
     pub privacy_checked: Arc<AtomicBool>,
     /// Snapshot of the latest known CLI release, refreshed by the GitHub
@@ -93,6 +98,7 @@ impl AppState {
                 cfg.passkey_ceremony_rate,
                 cfg.passkey_ceremony_burst,
             ),
+            web_pair_limiter: Limiter::new(cfg.web_pair_rate, cfg.web_pair_burst),
             owner_hasher: OwnerHasher::new(),
             privacy_checked: Arc::new(AtomicBool::new(false)),
             auth: Authenticator::new(cfg.api_key_pepper.clone(), api_keys.clone()),
@@ -113,6 +119,7 @@ impl AppState {
         self.api_limiter.start_gc(interval, max_idle);
         self.apikey_register_limiter.start_gc(interval, max_idle);
         self.passkey_ceremony_limiter.start_gc(interval, max_idle);
+        self.web_pair_limiter.start_gc(interval, max_idle);
     }
 
     pub fn stop_limiter_gc(&self) {
@@ -121,6 +128,7 @@ impl AppState {
         self.api_limiter.stop();
         self.apikey_register_limiter.stop();
         self.passkey_ceremony_limiter.stop();
+        self.web_pair_limiter.stop();
     }
 }
 
@@ -4082,7 +4090,7 @@ pub async fn handle_pair_start_entry(State(state): State<Arc<AppState>>, req: Re
     }
 
     let ip = get_client_ip(req.headers(), request_connect_addr(&req));
-    if !state.apikey_register_limiter.allow(&ip) {
+    if !state.web_pair_limiter.allow(&ip) {
         return rate_limited();
     }
 
@@ -4179,7 +4187,7 @@ pub async fn handle_pair_poll_entry(State(state): State<Arc<AppState>>, req: Req
     }
 
     let ip = get_client_ip(req.headers(), request_connect_addr(&req));
-    if !state.apikey_register_limiter.allow(&ip) {
+    if !state.web_pair_limiter.allow(&ip) {
         return rate_limited();
     }
 
@@ -4259,7 +4267,7 @@ pub async fn handle_pair_claim_entry(State(state): State<Arc<AppState>>, req: Re
     }
 
     let ip = get_client_ip(req.headers(), request_connect_addr(&req));
-    if !state.apikey_register_limiter.allow(&ip) {
+    if !state.web_pair_limiter.allow(&ip) {
         return rate_limited();
     }
 
@@ -4400,7 +4408,7 @@ pub async fn handle_pair_challenge_entry(
     }
 
     let ip = get_client_ip(req.headers(), request_connect_addr(&req));
-    if !state.apikey_register_limiter.allow(&ip) {
+    if !state.web_pair_limiter.allow(&ip) {
         return rate_limited();
     }
 
@@ -4462,7 +4470,7 @@ pub async fn handle_pair_approve_entry(
     }
 
     let ip = get_client_ip(req.headers(), request_connect_addr(&req));
-    if !state.apikey_register_limiter.allow(&ip) {
+    if !state.web_pair_limiter.allow(&ip) {
         return rate_limited();
     }
 
@@ -4580,7 +4588,7 @@ pub async fn handle_pair_cancel_entry(
     }
 
     let ip = get_client_ip(req.headers(), request_connect_addr(&req));
-    if !state.apikey_register_limiter.allow(&ip) {
+    if !state.web_pair_limiter.allow(&ip) {
         return rate_limited();
     }
 
@@ -6636,6 +6644,8 @@ mod tests {
             apikey_register_ip_max_per_day: 20,
             passkey_ceremony_rate: 100.0,
             passkey_ceremony_burst: 100,
+            web_pair_rate: 1000.0,
+            web_pair_burst: 1000,
             encrypted_notes_enabled: false,
 
             github_poll_interval_seconds: 0,

--- a/crates/secrt-server/tests/api_error_paths.rs
+++ b/crates/secrt-server/tests/api_error_paths.rs
@@ -58,6 +58,8 @@ fn cfg() -> Config {
         apikey_register_ip_max_per_day: 20,
         passkey_ceremony_rate: 1000.0,
         passkey_ceremony_burst: 1000,
+        web_pair_rate: 1000.0,
+        web_pair_burst: 1000,
         encrypted_notes_enabled: false,
 
         github_poll_interval_seconds: 0,

--- a/crates/secrt-server/tests/helpers/mod.rs
+++ b/crates/secrt-server/tests/helpers/mod.rs
@@ -1015,6 +1015,8 @@ pub fn test_config() -> Config {
         // that exercise the limiter override these directly.
         passkey_ceremony_rate: 100.0,
         passkey_ceremony_burst: 100,
+        web_pair_rate: 1000.0,
+        web_pair_burst: 1000,
         encrypted_notes_enabled: false,
 
         github_poll_interval_seconds: 0,

--- a/crates/secrt-server/tests/web_pair.rs
+++ b/crates/secrt-server/tests/web_pair.rs
@@ -23,18 +23,6 @@ use helpers::{test_app_with_store, test_config, with_remote, MemStore};
 use serde_json::{json, Value};
 use tower::ServiceExt;
 
-/// Test config tuned for the pair endpoints: every pair endpoint goes
-/// through `apikey_register_limiter`, and tests routinely make 8+ pair
-/// calls from the in-process "IP" — the default `apikey_register_burst: 6`
-/// trips and produces spurious 429s. Bumping just this one knob keeps the
-/// rest of the rate-limit story honest.
-fn test_config_high_pair_rate() -> secrt_server::config::Config {
-    let mut cfg = test_config();
-    cfg.apikey_register_rate = 100.0;
-    cfg.apikey_register_burst = 1000;
-    cfg
-}
-
 // Valid 65-byte uncompressed P-256 public keys (0x04 + 64 bytes), base64url.
 // Reused verbatim from the device-auth test fixtures at
 // `crates/secrt-server/src/http/mod.rs` so the exact-byte-shape validators
@@ -194,7 +182,7 @@ fn count_web_pair_rows(store: &Arc<MemStore>) -> usize {
 #[tokio::test]
 async fn pair_role_receive_end_to_end() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     // Receiver displays: /start with pubkey.
@@ -244,7 +232,7 @@ async fn pair_role_receive_end_to_end() {
 #[tokio::test]
 async fn pair_role_send_end_to_end() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let start = body_json(pair_start(&app, &token, json!({ "role": "send" })).await).await;
@@ -282,7 +270,7 @@ async fn pair_role_send_end_to_end() {
 #[tokio::test]
 async fn pair_rejects_cross_user() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let alice = register_user(&app, "Alice").await;
     let bob = register_user(&app, "Bob").await;
 
@@ -326,7 +314,7 @@ async fn pair_rejects_cross_user() {
 #[tokio::test]
 async fn pair_approve_does_not_mint_api_key() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
     let api_keys_before = store.keys.lock().unwrap().len();
 
@@ -354,7 +342,7 @@ async fn pair_approve_does_not_mint_api_key() {
 #[tokio::test]
 async fn pair_claim_rejects_wrong_code() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
     let _ = pair_start(&app, &token, json!({ "role": "send" })).await;
 
@@ -370,7 +358,7 @@ async fn pair_claim_rejects_wrong_code() {
 #[tokio::test]
 async fn pair_claim_rejects_after_pubkey_already_set() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let start = body_json(pair_start(&app, &token, json!({ "role": "send" })).await).await;
@@ -392,7 +380,7 @@ async fn pair_claim_rejects_after_pubkey_already_set() {
 #[tokio::test]
 async fn pair_claim_concurrent_double_claim() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let start = body_json(pair_start(&app, &token, json!({ "role": "send" })).await).await;
@@ -426,7 +414,7 @@ async fn pair_claim_concurrent_double_claim() {
 #[tokio::test]
 async fn pair_cancel_terminates_polls() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let start = body_json(pair_start(&app, &token, json!({ "role": "send" })).await).await;
@@ -460,7 +448,7 @@ async fn pair_cancel_terminates_polls() {
 #[tokio::test]
 async fn pair_no_ip_in_poll_response() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let start = body_json(pair_start(&app, &token, json!({ "role": "send" })).await).await;
@@ -488,7 +476,7 @@ async fn pair_no_ip_in_poll_response() {
 #[tokio::test]
 async fn pair_slot_deleted_at_expiry() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let _ = pair_start(
@@ -521,7 +509,7 @@ async fn pair_slot_deleted_at_expiry() {
 #[tokio::test]
 async fn pair_challenge_returns_409_for_terminal_states() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     // 'cancelled' state.
@@ -569,7 +557,7 @@ async fn pair_challenge_returns_409_for_terminal_states() {
 #[tokio::test]
 async fn pair_amk_transfer_field_validation() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let s = body_json(
@@ -617,7 +605,7 @@ async fn pair_amk_transfer_field_validation() {
 #[tokio::test]
 async fn pair_start_role_pubkey_validation() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     // role=receive without pubkey → 400.
@@ -652,7 +640,7 @@ async fn pair_start_role_pubkey_validation() {
 #[tokio::test]
 async fn pair_endpoints_reject_wrong_method() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
 
     // Use a real session token so we get past auth and hit the method check.
     // (Method check fires before auth in our handlers.)
@@ -694,7 +682,7 @@ async fn pair_endpoints_reject_wrong_method() {
 #[tokio::test]
 async fn pair_poll_unknown_token_returns_expired() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let resp = pair_poll(&app, &token, "totally-bogus-token-that-does-not-exist").await;
@@ -715,7 +703,7 @@ async fn pair_poll_unknown_token_returns_expired() {
 #[tokio::test]
 async fn pair_cancel_by_joiner_poll_token() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     let start = body_json(pair_start(&app, &token, json!({ "role": "send" })).await).await;
@@ -744,7 +732,7 @@ async fn pair_cancel_by_joiner_poll_token() {
 #[tokio::test]
 async fn pair_cancel_idempotent_after_terminal() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
     let token = register_user(&app, "Alice").await;
 
     // Already-cancelled slot.
@@ -784,7 +772,7 @@ async fn pair_cancel_idempotent_after_terminal() {
 #[tokio::test]
 async fn pair_endpoints_require_session_auth() {
     let store = Arc::new(MemStore::default());
-    let app = test_app_with_store(store.clone(), test_config_high_pair_rate());
+    let app = test_app_with_store(store.clone(), test_config());
 
     let no_auth = |method: &str, path: &str, body: Option<Value>| {
         let req = Request::builder()


### PR DESCRIPTION
## Summary

Manual pair-flow testing was hitting \`429\`s after a few interactions because all six \`/auth/pair/*\` handlers were sharing \`apikey_register_limiter\` (default \`0.5 rps, burst 6\` — tuned for API-key minting, not for a flow that polls every few hundred milliseconds while a slot is open).

This PR carves out a dedicated \`web_pair_limiter\` with defaults sized for a real pair UX and adds dev-friendly env knobs.

## Changes

- **Config:** \`web_pair_rate: f64\` (default \`2.0\`) and \`web_pair_burst: usize\` (default \`30\`), wired through \`WEB_PAIR_RATE\` / \`WEB_PAIR_BURST\` env vars.
- **AppState:** new \`web_pair_limiter\` with the standard GC lifecycle.
- **Handlers:** six pair handlers (\`/start\`, \`/poll\`, \`/claim\`, \`/challenge\`, \`/approve\`, \`/cancel\`) switch from \`apikey_register_limiter\` to \`web_pair_limiter\`. No change to which IP is rate-limited or to the response shape.
- **\`.env.example\`:** new section documenting the env vars + a hint for local-dev override (\`WEB_PAIR_RATE=100\`, \`WEB_PAIR_BURST=1000\`).
- **Tests:** \`test_config_high_pair_rate\` helper in \`crates/secrt-server/tests/web_pair.rs\` retired — its sole purpose was hoisting \`apikey_register_burst\` to keep multi-call tests from tripping. \`test_config()\` now provides web-pair limits high enough for the suite (1000, 1000 in test helpers).
- **CHANGELOG:** entry added under \`## 0.18.0\` (still pending tag).

## Why these defaults

A single pair round trip can take ~15 ops in a tight cluster (start → claim → several polls while waiting → challenge → approve → cancel). \`burst: 30\` absorbs that with margin. \`rate: 2.0\` rps sustained covers continuous polling at the 500 ms cadence the UI uses, indefinitely. Slot-creation abuse is still bounded — an attacker can't sustainably spam \`/start\` faster than 2 slots/sec/IP.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`make lint-rust\` clean
- [x] \`make test-rust\` — 1227 pass, 11 skipped (including 20 web_pair integration tests now using the default config)
- [ ] Manual: \`WEB_PAIR_RATE=100\` / \`WEB_PAIR_BURST=1000\` in \`.env\`, exercise the \`/pair\` UI repeatedly — no spurious 429s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable rate limiting for Web-to-Web pairing endpoints via WEB_PAIR_RATE (default 2.0) and WEB_PAIR_BURST (default 30).

* **Documentation**
  * Updated changelog and example env docs to describe the new pairing endpoint limits and dev override guidance.

* **Tests**
  * Test suite updated to rely on the new default pairing limits; helper/test config simplified accordingly.

* **Chores**
  * CI/review config updated to improve changelog review rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getsecrt/secrt/pull/47)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->