### PR TITLE
fix(server,desktop): allow blob: workers and self camera in CSP

### DIFF
--- a/crates/secrt-desktop/tauri.conf.json
+++ b/crates/secrt-desktop/tauri.conf.json
@@ -29,7 +29,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://secrt.ca https://secrt.is; img-src 'self' data: blob:; font-src 'self' data:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://secrt.ca https://secrt.is; img-src 'self' data: blob:; font-src 'self' data:; worker-src 'self' blob:"
     }
   },
   "bundle": {

--- a/crates/secrt-server/src/http/security.rs
+++ b/crates/secrt-server/src/http/security.rs
@@ -20,7 +20,7 @@ const CSP_TEMPLATE_TAIL: &str = "; style-src 'self'; \
      font-src 'self'; \
      connect-src 'self'; \
      manifest-src 'self'; \
-     worker-src 'self'; \
+     worker-src 'self' blob:; \
      form-action 'none'; \
      base-uri 'none'; \
      frame-ancestors 'none'; \
@@ -35,7 +35,7 @@ const CSP_NAME: HeaderName = HeaderName::from_static("content-security-policy");
 const COOP_VALUE: HeaderValue = HeaderValue::from_static("same-origin");
 const CORP_VALUE: HeaderValue = HeaderValue::from_static("same-origin");
 const PERMISSIONS_POLICY_VALUE: HeaderValue = HeaderValue::from_static(
-    "accelerometer=(), camera=(), geolocation=(), gyroscope=(), \
+    "accelerometer=(), camera=(self), geolocation=(), gyroscope=(), \
      microphone=(), payment=(), usb=(), interest-cohort=()",
 );
 const NO_STORE_VALUE: HeaderValue = HeaderValue::from_static("no-store");
@@ -199,6 +199,23 @@ mod tests {
         assert!(csp.contains("upgrade-insecure-requests"));
         assert!(!csp.contains("'unsafe-inline'"));
         assert!(!csp.contains("'unsafe-eval'"));
+        // The qr-scanner library used by the pair flow constructs its
+        // decoder via `new Worker(URL.createObjectURL(new Blob([...])))`,
+        // so `blob:` must remain in `worker-src` or the camera-based pair
+        // flow silently stalls in production. See
+        // .taskmaster/plans/qr-scanner-csp-worker-src-fix.md.
+        assert!(csp.contains("worker-src 'self' blob:"));
+    }
+
+    #[test]
+    fn permissions_policy_allows_self_camera() {
+        // First-party camera is required for the pair-flow QR scanner and
+        // future secrt-receive flows. Denying it (`camera=()`) leaves
+        // Safari permissive but breaks Chrome/Firefox getUserMedia.
+        let value = PERMISSIONS_POLICY_VALUE;
+        let v = value.to_str().unwrap();
+        assert!(v.contains("camera=(self)"));
+        assert!(v.contains("microphone=()"));
     }
 
     #[test]

--- a/crates/secrt-server/tests/api_behavior.rs
+++ b/crates/secrt-server/tests/api_behavior.rs
@@ -444,7 +444,7 @@ async fn method_not_allowed_and_headers() {
         .and_then(|v| v.to_str().ok())
         .expect("permissions-policy header");
     for token in [
-        "camera=()",
+        "camera=(self)",
         "geolocation=()",
         "microphone=()",
         "interest-cohort=()",


### PR DESCRIPTION
## Summary

- **CSP `worker-src 'self'` blocked the qr-scanner library's blob: worker**, so on `/pair` the camera preview started but no QR code was ever decoded — the modal sat on a live preview with no error UI. Widens to `worker-src 'self' blob:`.
- **Permissions-Policy `camera=()` was wrong** for any flow that intentionally uses the camera. Changes to `camera=(self)`. Safari is silently permissive about Permissions-Policy on top-level docs (which is why JD still saw a preview on iPhone Safari despite this), but Chrome/Firefox would have refused `getUserMedia` outright on those browsers — both behaviors are now correct.
- **Mirror the `worker-src` widening into the Tauri shell CSP** so the same regression can't silently surface there.

Both widenings are the standard, accepted minimum for inline-worker libraries (qr-scanner, pdf.js, mapbox-gl, monaco, etc.) and first-party camera use. Neither weakens any defense the threat model relied on — see plan for rationale.

Pinned in tests:
- `security.rs` unit tests now assert both `worker-src 'self' blob:` in the CSP and `camera=(self)` / `microphone=()` in Permissions-Policy.
- `api_behavior.rs` integration test updated to expect `camera=(self)` on a real response.

Plan: `.taskmaster/plans/qr-scanner-csp-worker-src-fix.md`

## Test plan

- [x] `cargo fmt --all`
- [x] `make lint-rust` — clean
- [x] `make test-rust` — 1227 tests pass
- [ ] Desktop Safari + webcam: load `/pair`, open scanner, confirm no CSP errors in console and a real QR decodes (catches the worker-src fix; CSP3 worker-src parsing is shared WebKit code)
- [ ] Chrome desktop + Firefox desktop: same flow (catches the `camera=(self)` widening — these browsers were the ones that *would* have refused `getUserMedia` outright)
- [ ] Real iPhone Safari (the originally reported surface): deploy to `secrt.is` first and verify before promoting to `secrt.ca`
- [ ] With `localStorage.setItem('secrt:debug','1')`, confirm `[secrt:qr-scanner] decode` fires when a known-good code is in frame

## Out of scope (filed separately per plan)

- The `style-src` inline-stylesheet error on `/pair` — separate inline-styles audit
- Soak-process gap (need camera-flow line item in CSP-promotion checklist)
- `QrScanner.tsx` UX could surface worker-creation failures as an error state instead of stalling silently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled camera access for the application
  * Enhanced support for background worker functionality

* **Tests**
  * Updated security policy and permissions verification tests

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getsecrt/secrt/pull/49)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->