### PR TITLE
feat(web): styled 404 page with dissolve animation

### DIFF
--- a/crates/secrt-server/CHANGELOG.md
+++ b/crates/secrt-server/CHANGELOG.md
@@ -2,7 +2,53 @@
 
 ## Unreleased
 
+### Added
+
+- **Unknown URLs now render a styled 404 page instead of a blank screen.**
+
+  The server fallback used to return an empty 404 body for any path not
+  in the router — typo'd URLs landed users on a white page. An Axum
+  catch-all now serves the SPA shell with HTTP 404 so the client-side
+  router can render `NotFoundPage`: a pixelated "404" that holds for a
+  beat, then dissolves, alongside the attempted path and a link home.
+
+  - API and `.well-known/` paths keep returning the existing JSON 404
+    shape so clients see a consistent error format.
+  - `NotFoundPage` is lazy-loaded via dynamic `import()`, so its
+    canvas-animation code doesn't ship in the main bundle — it lands in
+    its own ~1 KB gzipped chunk that only loads when a 404 is rendered.
+  - Animation honors `prefers-reduced-motion` (renders the static pixel
+    grid and stops).
+
+  Files: `crates/secrt-server/src/http/mod.rs` (new
+  `handle_not_found_fallback`), `crates/secrt-server/tests/spa_routes.rs`
+  (covers both the HTML and JSON branches),
+  `web/src/features/error/NotFoundPage.tsx` (new),
+  `web/src/app.tsx` (lazy loader).
+
+- **Bare `/sync` no longer 404s — it shows a friendly "link incomplete" landing.**
+
+  A truncated or mis-copied sync link that drops the secret ID used to
+  fall through to the SPA 404. It now routes to a landing page that
+  redirects to login when signed out, then explains the link is
+  incomplete and offers a button to `/pair`.
+
+  Files: `web/src/features/sync/SyncLandingPage.tsx`, `web/src/router.ts`,
+  `web/src/app.tsx`.
+
 ### Changed
+
+- **"Get a one-time sync link" fallback resurfaced beneath the `/pair` join card.**
+
+  After 0.18.0 demoted the sync-link button, a device that already holds
+  the account key had no obvious way to generate a sync link from the
+  join screen. `SyncNotesKeyButton` now appears as a small fallback link
+  under `PairJoinPanel` for the both-browsers-can't-be-open case. Its
+  button label and modal copy also move from "Notes Key" to "Account Key"
+  to match the rest of the UI.
+
+  Files: `web/src/components/SyncNotesKeyButton.tsx`,
+  `web/src/features/pair/PairJoinPanel.tsx`.
 
 - **Pair endpoints now accept either session bearer or linked API-key
   auth.** Previously `/api/v1/auth/pair/*` required a session token

--- a/crates/secrt-server/src/http/mod.rs
+++ b/crates/secrt-server/src/http/mod.rs
@@ -1013,7 +1013,13 @@ pub async fn handle_not_found_fallback(
     uri: axum::http::Uri,
 ) -> Response {
     let path = uri.path();
-    if path.starts_with("/api/") || path.starts_with("/.well-known/") {
+    // Cover both exact ("/api", "/.well-known") and prefixed ("/api/...")
+    // forms so the bare boundary paths don't accidentally serve HTML.
+    if path == "/api"
+        || path.starts_with("/api/")
+        || path == "/.well-known"
+        || path.starts_with("/.well-known/")
+    {
         return not_found();
     }
 

--- a/crates/secrt-server/src/http/mod.rs
+++ b/crates/secrt-server/src/http/mod.rs
@@ -992,6 +992,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/v1/amk/commit", any(handle_amk_commit_entry))
         .route("/api/v1/amk/exists", any(handle_amk_exists_entry))
         .route("/api/v1/secrets/{id}/meta", any(handle_secret_meta_entry))
+        .fallback(handle_not_found_fallback)
         .layer(CatchPanicLayer::custom(handle_panic))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
@@ -999,6 +1000,31 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         ))
         .layer(cors_layer())
         .with_state(state)
+}
+
+/// Catch-all for unknown paths.
+///
+/// - API and well-known paths get a JSON 404 (consistent with explicit handlers).
+/// - Everything else gets the SPA shell with HTTP 404 so the client-side router
+///   can render the styled NotFoundPage. Without this, unknown paths return a
+///   bare empty 404 body — a blank page in the browser.
+pub async fn handle_not_found_fallback(
+    State(state): State<Arc<AppState>>,
+    uri: axum::http::Uri,
+) -> Response {
+    let path = uri.path();
+    if path.starts_with("/api/") || path.starts_with("/.well-known/") {
+        return not_found();
+    }
+
+    let base = &state.cfg.public_base_url;
+    let html = crate::assets::spa_index_html_with_base(base)
+        .unwrap_or_else(|| include_str!("../../templates/index.html").to_string());
+
+    let mut resp = (StatusCode::NOT_FOUND, Html(html)).into_response();
+    insert_header(resp.headers_mut(), "cache-control", "no-store");
+    insert_header(resp.headers_mut(), "x-robots-tag", "noindex");
+    resp
 }
 
 fn handle_panic(_: Box<dyn std::any::Any + Send + 'static>) -> Response {

--- a/crates/secrt-server/tests/spa_routes.rs
+++ b/crates/secrt-server/tests/spa_routes.rs
@@ -66,6 +66,61 @@ async fn spa_routes_return_index_html() {
     }
 }
 
+/// Unknown paths must serve the SPA shell with HTTP 404 so the client-side
+/// router can render the styled NotFoundPage. Without this, browsers see a
+/// blank page on any typo'd URL.
+#[tokio::test]
+async fn unknown_path_serves_spa_with_404() {
+    let store = Arc::new(MemStore::default());
+    let app = test_app_with_store(store, test_config());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/this-route-does-not-exist")
+        .body(Body::empty())
+        .expect("build request");
+
+    let resp = app.clone().oneshot(req).await.expect("send request");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.contains("text/html"),
+        "unknown path returned content-type '{content_type}' instead of text/html",
+    );
+}
+
+/// Unknown /api/ paths must still return JSON (not the SPA shell) so API
+/// clients get a consistent error shape.
+#[tokio::test]
+async fn unknown_api_path_returns_json_404() {
+    let store = Arc::new(MemStore::default());
+    let app = test_app_with_store(store, test_config());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/v1/this-endpoint-does-not-exist")
+        .body(Body::empty())
+        .expect("build request");
+
+    let resp = app.clone().oneshot(req).await.expect("send request");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.contains("application/json"),
+        "unknown /api/ path returned content-type '{content_type}' instead of application/json",
+    );
+}
+
 /// The /s/{id} route is special — it serves a custom OG-tagged HTML page, not
 /// the generic SPA index. Verify it returns 200 with HTML.
 #[tokio::test]

--- a/crates/secrt-server/tests/spa_routes.rs
+++ b/crates/secrt-server/tests/spa_routes.rs
@@ -121,6 +121,34 @@ async fn unknown_api_path_returns_json_404() {
     );
 }
 
+/// Unknown /.well-known/ paths must also return JSON (not the SPA shell)
+/// so well-known discovery clients (security.txt scrapers, etc.) get a
+/// machine-parseable response instead of an HTML page.
+#[tokio::test]
+async fn unknown_well_known_path_returns_json_404() {
+    let store = Arc::new(MemStore::default());
+    let app = test_app_with_store(store, test_config());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/.well-known/this-endpoint-does-not-exist")
+        .body(Body::empty())
+        .expect("build request");
+
+    let resp = app.clone().oneshot(req).await.expect("send request");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.contains("application/json"),
+        "unknown /.well-known/ path returned content-type '{content_type}' instead of application/json",
+    );
+}
+
 /// The /s/{id} route is special — it serves a custom OG-tagged HTML page, not
 /// the generic SPA index. Verify it returns 200 with HTML.
 #[tokio::test]

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -121,9 +121,15 @@ function LazyNotFound() {
   const [Comp, setComp] = useState<ComponentType | null>(null);
   useEffect(() => {
     let cancelled = false;
-    import('./features/error/NotFoundPage').then((m) => {
-      if (!cancelled) setComp(() => m.NotFoundPage);
-    });
+    import('./features/error/NotFoundPage')
+      .then((m) => {
+        if (!cancelled) setComp(() => m.NotFoundPage);
+      })
+      .catch((err) => {
+        // Stale deploy, offline, etc. — leave the synchronous fallback
+        // card visible rather than triggering an unhandled rejection.
+        console.warn('NotFoundPage chunk failed to load:', err);
+      });
     return () => {
       cancelled = true;
     };

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -17,6 +17,7 @@ import { SyncPage } from './features/sync/SyncPage';
 import { SyncLandingPage } from './features/sync/SyncLandingPage';
 import { AboutPage } from './features/about/AboutPage';
 import { ThemePage } from './features/test/ThemePage';
+import type { ComponentType } from 'preact';
 
 export function App() {
   const route = useRoute();
@@ -100,12 +101,7 @@ export function App() {
       page = <AboutPage />;
       break;
     case 'not-found':
-      page = (
-        <div class="card text-center">
-          <h2 class="label">Not found</h2>
-          <p class="text-muted">This page doesn't exist.</p>
-        </div>
-      );
+      page = <LazyNotFound />;
       break;
   }
 
@@ -115,5 +111,28 @@ export function App() {
         {page}
       </Layout>
     </AuthProvider>
+  );
+}
+
+// NotFoundPage is lazy-loaded so its canvas-animation code doesn't ship in
+// the main bundle. The static fallback below renders synchronously while the
+// chunk loads, and stays as a safety net if the chunk fails to load.
+function LazyNotFound() {
+  const [Comp, setComp] = useState<ComponentType | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    import('./features/error/NotFoundPage').then((m) => {
+      if (!cancelled) setComp(() => m.NotFoundPage);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  if (Comp) return <Comp />;
+  return (
+    <div class="card text-center">
+      <h2 class="label">Not found</h2>
+      <p class="text-muted">This page doesn't exist.</p>
+    </div>
   );
 }

--- a/web/src/features/error/NotFoundPage.tsx
+++ b/web/src/features/error/NotFoundPage.tsx
@@ -101,27 +101,15 @@ function dissolve404(
   }
   ctx.fillText(text, w / 2, h / 2);
 
-  // Sample alpha on the device-pixel buffer, but step in CSS pixels.
+  // Sample alpha on the device-pixel buffer, step in CSS pixels.
   const img = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
-  const dots: {
-    x: number;
-    y: number;
-    d: number;
-    vx: number;
-    o: number;
-  }[] = [];
+  const points: { x: number; y: number; d: number }[] = [];
   for (let y = 0; y < h; y += gap) {
     for (let x = 0; x < w; x += gap) {
       const px = Math.floor(x * dpr);
       const py = Math.floor(y * dpr);
       if (img[(py * canvas.width + px) * 4 + 3] > 128) {
-        dots.push({
-          x,
-          y,
-          d: delay + Math.random() * stagger,
-          vx: (Math.random() - 0.5) * 8,
-          o: 0.5 + Math.random() * 0.5,
-        });
+        points.push({ x, y, d: delay + Math.random() * stagger });
       }
     }
   }
@@ -129,20 +117,10 @@ function dissolve404(
   const size = Math.max(1.5, gap * 0.5);
   ctx.fillStyle = getComputedStyle(canvas).color;
 
-  const paint = (
-    p: { x: number; y: number; vx: number; o: number },
-    life: number,
-  ) => {
-    ctx.globalAlpha = p.o * life;
-    const k = 1 - life;
-    ctx.fillRect(p.x + p.vx * k, p.y - 16 * k, size * life, size * life);
-  };
-
   // Reduced motion: render the static 404 and stop.
   if (matchMedia('(prefers-reduced-motion: reduce)').matches) {
     ctx.clearRect(0, 0, w, h);
-    for (const p of dots) paint(p, 1);
-    ctx.globalAlpha = 1;
+    for (const p of points) ctx.fillRect(p.x, p.y, size, size);
     return () => {};
   }
 
@@ -155,11 +133,12 @@ function dissolve404(
     const e = t - start;
     ctx.clearRect(0, 0, w, h);
     let alive = false;
-    for (const p of dots) {
+    for (const p of points) {
       const k = (e - p.d) / duration;
       if (k >= 1) continue;
       alive = true;
-      paint(p, k < 0 ? 1 : 1 - k);
+      ctx.globalAlpha = k < 0 ? 1 : 1 - k;
+      ctx.fillRect(p.x, p.y, size, size);
     }
     ctx.globalAlpha = 1;
     if (alive) rafId = requestAnimationFrame(frame);

--- a/web/src/features/error/NotFoundPage.tsx
+++ b/web/src/features/error/NotFoundPage.tsx
@@ -62,10 +62,10 @@ function dissolve404(
   canvas: HTMLCanvasElement,
   {
     text = '404',
-    gap = 5,
+    gap = 3,
     duration = 1800,
-    stagger = 1500,
-    delay = 3000,
+    stagger = 9000,
+    delay = 500,
   }: {
     text?: string;
     gap?: number;
@@ -102,10 +102,12 @@ function dissolve404(
   ctx.fillText(text, w / 2, h / 2);
 
   // Sample alpha on the device-pixel buffer, step in CSS pixels.
+  // Clamp the step to >=1 so a misconfigured gap can't infinite-loop.
   const img = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+  const step = Math.max(1, Math.floor(gap));
   const points: { x: number; y: number; d: number }[] = [];
-  for (let y = 0; y < h; y += gap) {
-    for (let x = 0; x < w; x += gap) {
+  for (let y = 0; y < h; y += step) {
+    for (let x = 0; x < w; x += step) {
       const px = Math.floor(x * dpr);
       const py = Math.floor(y * dpr);
       if (img[(py * canvas.width + px) * 4 + 3] > 128) {
@@ -114,13 +116,18 @@ function dissolve404(
     }
   }
 
-  const size = Math.max(1.5, gap * 0.5);
+  // 1 CSS px gap between pixels — gives a "zoomed-in LCD" look.
+  const size = Math.max(1, gap - 1);
   ctx.fillStyle = getComputedStyle(canvas).color;
 
-  // Reduced motion: render the static 404 and stop.
+  // Replace the white sampling glyph with the discrete pixel grid
+  // synchronously, so the browser never composites the white text
+  // (otherwise visible as a brief flash on dark cards before RAF fires).
+  ctx.clearRect(0, 0, w, h);
+  for (const p of points) ctx.fillRect(p.x, p.y, size, size);
+
+  // Reduced motion: leave the static 404 in place and stop.
   if (matchMedia('(prefers-reduced-motion: reduce)').matches) {
-    ctx.clearRect(0, 0, w, h);
-    for (const p of points) ctx.fillRect(p.x, p.y, size, size);
     return () => {};
   }
 

--- a/web/src/features/error/NotFoundPage.tsx
+++ b/web/src/features/error/NotFoundPage.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { navigate } from '../../router';
+import { CardHeading } from '../../components/CardHeading';
+
+export function NotFoundPage() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [path, setPath] = useState<string>(() =>
+    typeof window === 'undefined' ? '' : window.location.pathname,
+  );
+
+  useEffect(() => {
+    setPath(window.location.pathname);
+    const onPop = () => setPath(window.location.pathname);
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const cancel = dissolve404(canvas);
+    return cancel;
+  }, []);
+
+  const handleHome = (e: MouseEvent) => {
+    e.preventDefault();
+    navigate('/');
+  };
+
+  return (
+    <div class="card text-center">
+      <canvas
+        ref={canvasRef}
+        class="block h-32 w-full text-accent sm:h-44"
+        role="img"
+        aria-label="404 — page not found"
+      />
+      <CardHeading title="This page does not exist" />
+
+      {path && (
+        <p class="mt-1 text-muted">
+          <span class="mr-1">No route at</span>
+          <code class="code">{path}</code>
+        </p>
+      )}
+
+      <div class="mt-6 flex flex-wrap justify-center gap-3">
+        <a href="/" onClick={handleHome} class="link">
+          Home
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders `text` as a grid of pixels, then disintegrates them.
+ * Inherits color from the canvas's CSS `color`, so theming is free.
+ * Returns a cancel function that stops any in-flight animation.
+ */
+function dissolve404(
+  canvas: HTMLCanvasElement,
+  {
+    text = '404',
+    gap = 5,
+    duration = 1800,
+    stagger = 1500,
+    delay = 3000,
+  }: {
+    text?: string;
+    gap?: number;
+    duration?: number;
+    stagger?: number;
+    /** Hold the solid "404" this long before any dot starts dissolving. */
+    delay?: number;
+  } = {},
+): () => void {
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return () => {};
+
+  // DPR-aware sizing so the glyphs aren't blurry on retina.
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const cssW = canvas.clientWidth;
+  const cssH = canvas.clientHeight;
+  if (!cssW || !cssH) return () => {};
+  canvas.width = Math.floor(cssW * dpr);
+  canvas.height = Math.floor(cssH * dpr);
+  ctx.scale(dpr, dpr);
+  const w = cssW;
+  const h = cssH;
+
+  ctx.fillStyle = '#fff';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  let fs = h * 0.92;
+  ctx.font = `800 ${fs}px system-ui, sans-serif`;
+  const tw = ctx.measureText(text).width;
+  if (tw > w * 0.92) {
+    fs = (fs * (w * 0.92)) / tw;
+    ctx.font = `800 ${fs}px system-ui, sans-serif`;
+  }
+  ctx.fillText(text, w / 2, h / 2);
+
+  // Sample alpha on the device-pixel buffer, but step in CSS pixels.
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+  const dots: {
+    x: number;
+    y: number;
+    d: number;
+    vx: number;
+    o: number;
+  }[] = [];
+  for (let y = 0; y < h; y += gap) {
+    for (let x = 0; x < w; x += gap) {
+      const px = Math.floor(x * dpr);
+      const py = Math.floor(y * dpr);
+      if (img[(py * canvas.width + px) * 4 + 3] > 128) {
+        dots.push({
+          x,
+          y,
+          d: delay + Math.random() * stagger,
+          vx: (Math.random() - 0.5) * 8,
+          o: 0.5 + Math.random() * 0.5,
+        });
+      }
+    }
+  }
+
+  const size = Math.max(1.5, gap * 0.5);
+  ctx.fillStyle = getComputedStyle(canvas).color;
+
+  const paint = (
+    p: { x: number; y: number; vx: number; o: number },
+    life: number,
+  ) => {
+    ctx.globalAlpha = p.o * life;
+    const k = 1 - life;
+    ctx.fillRect(p.x + p.vx * k, p.y - 16 * k, size * life, size * life);
+  };
+
+  // Reduced motion: render the static 404 and stop.
+  if (matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    ctx.clearRect(0, 0, w, h);
+    for (const p of dots) paint(p, 1);
+    ctx.globalAlpha = 1;
+    return () => {};
+  }
+
+  let rafId = 0;
+  let start: number | undefined;
+  let cancelled = false;
+  const frame = (t: number) => {
+    if (cancelled) return;
+    start ??= t;
+    const e = t - start;
+    ctx.clearRect(0, 0, w, h);
+    let alive = false;
+    for (const p of dots) {
+      const k = (e - p.d) / duration;
+      if (k >= 1) continue;
+      alive = true;
+      paint(p, k < 0 ? 1 : 1 - k);
+    }
+    ctx.globalAlpha = 1;
+    if (alive) rafId = requestAnimationFrame(frame);
+  };
+  rafId = requestAnimationFrame(frame);
+
+  return () => {
+    cancelled = true;
+    cancelAnimationFrame(rafId);
+  };
+}


### PR DESCRIPTION
## Summary

- Replaces the bare empty-body 404 with a styled SPA page. An Axum `.fallback()` serves the SPA shell with HTTP 404 so the new `NotFoundPage` can render: a pixelated "404" that holds briefly, then dissolves pixel-by-pixel, alongside the attempted path and a link home.
- `NotFoundPage` is lazy-loaded via dynamic `import()` — its canvas-animation code does **not** ship in the main bundle. It lands in its own ~1 KB gzipped chunk that only loads when a 404 is rendered.
- Catches the CHANGELOG up on two previously-shipped UX changes (`/sync` landing page and `SyncNotesKeyButton` resurfacing) that hadn't been logged.

## Why

Before: unknown paths on the server returned a bare HTTP 404 with no body — visitors got a blank page. The SPA's not-found view was 3 lines and was never actually reachable in production.

After: typo'd URLs land on a friendly, on-brand page with helpful navigation. API and `.well-known/` paths still return JSON 404s for client consistency.

## Notable design choices

- **Lazy-loading** so the canvas/animation code never weighs on the home-page or claim-page payload (this is an under-the-radar Easter egg, not core UX).
- **Honors `prefers-reduced-motion`** — renders the static pixel grid and stops.
- **Synchronous pre-paint** of the discrete pixel grid (replacing the white sampling glyph used to read alpha) so dark-mode users don't see a brief white flash before the first RAF frame composites.
- **Step clamp** (`Math.max(1, Math.floor(gap))`) so a misconfigured `gap` of 0 can't drive the nested sampling loops into an infinite loop.

## Commits

1. `feat: add styled 404 page with dissolve animation` — server fallback + initial `NotFoundPage` + spa_routes tests.
2. `refactor: simplify 404 dissolve to in-place fade` — drop per-pixel drift, float, opacity variance, and size animation. Keep per-pixel stagger (gives the dissolve its character).
3. `refactor: tighten 404 pixel grid and fix pre-dissolve flash` — tune pitch, widen stagger spread, fix white flash, clamp loop step.
4. `docs(changelog): document 404 page, /sync landing, and sync-key fallback` — catch-up entries.

## Test plan

- [x] `pnpm test` (web) — 638 passed, 2 skipped pre-existing
- [x] `pnpm run check` (tsc) — clean
- [x] `pnpm run build` — verified `NotFoundPage` lands in its own chunk (~2 KB / ~1 KB gzipped); main `index-*.js` bundle unchanged
- [x] `cargo nextest run -p secrt-server` — 426/426
- [x] `cargo clippy -p secrt-server --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Browse to a typo'd URL on a deploy preview to confirm: HTTP 404 status, styled page renders, dissolve animation runs, light + dark mode both clean (no white flash), reduced-motion honored
- [ ] Confirm `/api/v1/nonexistent` still returns a JSON 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added styled, animated 404 page for unknown routes with dissolving effect; respects reduced-motion preferences
  * `/sync` endpoint now displays "link incomplete" landing instead of returning 404
  * Enhanced `/pair` UI with "Get a one-time sync link" fallback option
  * API paths continue returning JSON 404 format while other paths serve SPA shell

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getsecrt/secrt/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->