### PR TITLE
chore: bump version to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrt-cli"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "secrt-core"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "secrt-desktop"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "secrt-server"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/getsecrt/secrt"

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.19.0 — 2026-05-28
+
 ### Added
 
 - **`secrt pair` — share your account key between devices.** Mirrors the

--- a/crates/secrt-cli/Cargo.toml
+++ b/crates/secrt-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "secrt"
 path = "src/main.rs"
 
 [dependencies]
-secrt-core = { path = "../secrt-core", version = "0.18.1" }
+secrt-core = { path = "../secrt-core", version = "0.19.0" }
 ring.workspace = true
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 serde.workspace = true

--- a/crates/secrt-desktop/Cargo.toml
+++ b/crates/secrt-desktop/Cargo.toml
@@ -15,7 +15,7 @@ name = "secrt_desktop"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
-secrt-core = { path = "../secrt-core", version = "0.18.0" }
+secrt-core = { path = "../secrt-core", version = "0.19.0" }
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 keyring = "3"

--- a/crates/secrt-server/CHANGELOG.md
+++ b/crates/secrt-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.19.0 — 2026-05-28
+
 ### Added
 
 - **Unknown URLs now render a styled 404 page instead of a blank screen.**

--- a/crates/secrt-server/Cargo.toml
+++ b/crates/secrt-server/Cargo.toml
@@ -9,7 +9,7 @@ description = "Axum backend and admin tooling for secrt"
 default-run = "secrt-server"
 
 [dependencies]
-secrt-core = { path = "../secrt-core", version = "0.18.1" }
+secrt-core = { path = "../secrt-core", version = "0.19.0" }
 ring.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -471,7 +471,7 @@ mkdir -p /opt/secrt/bin
 # Set architecture (change to arm64 if needed)
 ARCH=amd64
 # Use the latest server release tag (check https://github.com/getsecrt/secrt/releases?q=server)
-VERSION="server/v0.18.1"
+VERSION="server/v0.19.0"
 
 cd /tmp
 gh release download "$VERSION" --repo getsecrt/secrt \
@@ -490,7 +490,7 @@ rm secrt-server-checksums-sha256.txt
 ```
 
 > **Note:** If `gh` is not installed, you can download directly:
-> `curl -fsSL -o /tmp/secrt-server-linux-${ARCH} "https://github.com/getsecrt/secrt/releases/download/server%2Fv0.18.1/secrt-server-linux-${ARCH}"`
+> `curl -fsSL -o /tmp/secrt-server-linux-${ARCH} "https://github.com/getsecrt/secrt/releases/download/server%2Fv0.19.0/secrt-server-linux-${ARCH}"`
 
 ### 7.2 Environment config
 


### PR DESCRIPTION
## Summary

Workspace version bump from 0.18.1 → 0.19.0. Both CLI and server ship in this release, so this PR's merge commit will be tagged as both `cli/v0.19.0` and `server/v0.19.0`.

### secrt-cli 0.19.0
- `secrt pair` — share your account key between devices (mirrors the web pair UI).
- User-facing vocabulary: "notes key" → "account key" everywhere.
- `secrt sync` marked `[legacy]` in help.

### secrt-server 0.19.0
- Styled 404 page (Axum `.fallback` + lazy SPA `NotFoundPage`) replaces the previous blank-page response on unknown URLs. API + `.well-known/` paths keep JSON 404s.
- Bare `/sync` shows a friendly "link incomplete" landing instead of 404.
- Pair endpoints accept either session bearer or linked API-key auth (additive — no `MIN_SUPPORTED_CLI_VERSION` bump).
- `SyncNotesKeyButton` resurfaced beneath `PairJoinPanel`, vocabulary updated.

## Wire compatibility

No wire-format changes. `MIN_SUPPORTED_CLI_VERSION` stays at `0.15.0`.

## Files changed

- `Cargo.toml` — workspace version
- `Cargo.lock` — auto-updated via `cargo check`
- `crates/secrt-cli/Cargo.toml`, `crates/secrt-server/Cargo.toml`, `crates/secrt-desktop/Cargo.toml` — `secrt-core` dep version
- `crates/secrt-cli/CHANGELOG.md`, `crates/secrt-server/CHANGELOG.md` — `## Unreleased` → `## 0.19.0 — 2026-05-28` (fresh empty Unreleased section preserved on top)
- `docs/self-hosting.md` — pinned `VERSION="server/vX.Y.Z"` and download-URL refs

## Tagging (after merge)

This PR is a `--merge` (preserve commit) candidate — the resulting merge commit IS the version-bump commit, so the tags will point at a stable SHA that doesn't get rewritten. From the YubiKey-equipped machine:

```sh
git checkout main && git pull --ff-only
git-tag-sk -m "secrt-cli v0.19.0" cli/v0.19.0
git-tag-sk -m "secrt-server v0.19.0" server/v0.19.0
git push origin cli/v0.19.0 server/v0.19.0
```

## Test plan

- [x] `cargo check --workspace --exclude secrt-desktop`
- [x] `cargo clippy --workspace --exclude secrt-desktop -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `pnpm run check`
- [x] `pnpm test`
- [ ] CI: full Rust + frontend matrix on ubuntu/macos/windows