### PR TITLE
CLI error messaging & failure-handling overhaul

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -198,9 +198,7 @@
         "description": "Register the app to handle secrt.ca URLs and/or a secrt:// custom protocol so clicking a share link opens the desktop app instead of the browser. Tauri 2 has a deep-link plugin. macOS Universal Links require an apple-app-site-association file on the server. Windows uses URI protocol handlers. Linux uses .desktop file handlers. Consider also registering for secrt:// as a fallback protocol.\n\nTracking: GitHub issue https://github.com/getsecrt/secrt/issues/30.",
         "status": "pending",
         "priority": "medium",
-        "dependencies": [
-          23
-        ],
+        "dependencies": [],
         "subtasks": [
           {
             "id": 1,
@@ -821,9 +819,7 @@
         "description": "Closes the supply-chain trust gap acknowledged in spec/v1/cli.md Trust Root and Supply-Chain Notes. Currently, secrt update verifies SHA-256 against a checksum file fetched from the same release - this protects against transport tampering but not against compromise of the GitHub release publishing pipeline. Sigstore/cosign keyless signing closes this: the release-cli.yml workflow signs each artifact and the checksum file with an ephemeral certificate tied to the GitHub Actions OIDC identity of the workflow. Signatures and cert chains are pushed to the public Rekor transparency log. The CLI verifies the signature against the Sigstore trust root plus a workflow identity (the secrt repo's release-cli.yml at a specific tag) before installing.\n\nWhy keyless: no long-lived signing key to manage, rotate, or accidentally expose. The trust root is GitHub Actions OIDC plus the public Rekor log.\n\nScope:\n1. Add cosign signing steps to .github/workflows/release-cli.yml. Sign each raw binary, each archive, and the secrt-checksums-sha256.txt file. Push signatures to the corresponding GitHub Release.\n2. Add Rust verifier to the secrt CLI's update flow. Use sigstore-rs or shell out to a bundled cosign binary. Verify signature before SHA-256 (transparency log assurance is stronger).\n3. Document the verification workflow in the README so users can manually verify a downloaded artifact.\n4. Decide policy: refuse install on signature failure (recommended) vs warn-and-continue (weaker but more recoverable). Refuse is the right call for a security-sensitive tool.\n\nReferences:\n- https://docs.sigstore.dev/cosign/keyless/\n- https://github.com/sigstore/sigstore-rs\n- https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect\n\nLand this PR before secrt has many users.",
         "status": "pending",
         "priority": "medium",
-        "dependencies": [
-          46
-        ],
+        "dependencies": [],
         "subtasks": [
           {
             "id": 1,
@@ -929,52 +925,6 @@
         "subtasks": []
       },
       {
-        "id": 68,
-        "title": "Browser-to-browser AMK transfer (pair-code + bidirectional QR)",
-        "description": "Full plan: .taskmaster/plans/task-68-amk-pair-code.md (May 2, 2026). Surface the existing XXXX-XXXX device-auth primitive as a web-to-web AMK transfer flow with a bidirectional rendezvous-QR. Replaces the killed listener/inbox/SSE design. Security upgrade over today payload-QR: rendezvous-QR carries only a slot ID + ephemeral pubkey, not the encrypted AMK blob. — Superseded by the simpler single-direction sender→receiver AMK pair flow shipped in 0.18.0. Bidirectional pair-code-or-QR rendezvous was deemed too confusing in practice; the typed 8-digit code primitive shipped as the no-camera fallback.",
-        "status": "cancelled",
-        "priority": "high",
-        "dependencies": [],
-        "subtasks": [
-          {
-            "id": 1,
-            "title": "Backend tweaks: role field on pairing slot + tests",
-            "status": "pending",
-            "description": "Confirm device-auth endpoints accept web-to-web case; add role (send/receive) to slot record; verify rate limits; explicit tests for both directions."
-          },
-          {
-            "id": 2,
-            "title": "Rendezvous URL scheme + QR render/scan helpers",
-            "status": "pending",
-            "description": "Define secrt://pair/{slot_id}?role=...&pk=... scheme. TS encode/decode helpers. QR render via existing lib. QR scan via jsQR (or qr-scanner wrapper). Skip native BarcodeDetector — Safari fallback dominates."
-          },
-          {
-            "id": 3,
-            "title": "PairDisplayPage (displaying-device UI)",
-            "status": "pending",
-            "description": "Role-aware: on receive, generate ECDH keypair and publish pubkey; on send, wait for joiner pubkey. Render QR + typed code as paired siblings. Poll for completion. Handle error states (expired, max attempts, decrypt failure)."
-          },
-          {
-            "id": 4,
-            "title": "PairJoinPage (joining-device UI)",
-            "status": "pending",
-            "description": "Two inputs: Scan QR (camera modal) + typed XXXX-XXXX. Both resolve to slot ID. Branch on slot role. Reuse DevicePage approval UX pattern. Display receivers UA/IP/time for sender confirmation."
-          },
-          {
-            "id": 5,
-            "title": "UX consolidation: demote sync link, retire payload-QR",
-            "status": "pending",
-            "description": "Sync link stays for async transfer, demoted to More options disclosure. Retire SyncNotesKeyButtons payload-QR rendering — sweep tests, docs, onboarding copy in the same commit."
-          },
-          {
-            "id": 6,
-            "title": "Spec updates + docs",
-            "status": "pending",
-            "description": "Add web-to-web AMK transfer section to spec/v1/server.md (URL scheme, role-aware slot semantics, security upgrade rationale). Update spec/v1/api.md if new fields land. Update web README."
-          }
-        ]
-      },
-      {
         "id": 71,
         "title": "Public docs: 'which passkey should I use with secrt?' explainer",
         "description": "User-facing docs page (NOT the internal architecture doc) that turns the cohort matrix into actionable recommendations: 'I'm an Apple user → use iCloud Keychain'; 'I have a YubiKey → great on Mac/Windows/Linux Chromium, also add an iCloud Keychain passkey for iPhone'; 'I use Bitwarden as my main vault → expect to use sync-links since their authenticator drops PRF.' Honesty about limitations without scaring people away. Lives at `docs/passkey-recommendations.md` or similar; linked from registration flow.",
@@ -982,6 +932,62 @@
         "priority": "low",
         "dependencies": [],
         "subtasks": []
+      },
+      {
+        "id": 72,
+        "title": "Richer 401 auth-failure message with shared status renderer",
+        "description": "On a 401, show the secrt auth status identity block (Key + Server with key-not-recognized state) inline, plus a hypothesis line and a secrt auth login recommendation. Share the line renderer between auth status and the error path. Route the --note/resolve_amk 401 through the same decorator (was bypassing it).",
+        "status": "done",
+        "priority": "medium",
+        "dependencies": [],
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Shared renderers in auth.rs",
+            "description": "fmt_key_line, fmt_server_line, masked_key_and_source, explain_auth_error; refactor run_auth_status to use them",
+            "status": "done"
+          },
+          {
+            "id": 2,
+            "title": "Rewrite decorate_auth_error",
+            "description": "Rich 401 message + json terse path + cross-instance hypothesis",
+            "status": "done"
+          },
+          {
+            "id": 3,
+            "title": "Wire call sites",
+            "description": "send (create + --note), burn, info, list",
+            "status": "done"
+          },
+          {
+            "id": 4,
+            "title": "Tests",
+            "description": "update + add unit tests",
+            "status": "done"
+          }
+        ]
+      },
+      {
+        "id": 73,
+        "title": "i18n readiness: separate machine signals from display strings",
+        "description": "Make the codebase localizable without committing to full i18n now. The expensive-to-retrofit piece is that control flow is detected by substring-matching human-readable display strings (e.g. e.contains(\"(401)\"), e.contains(\"404\") in get.rs/burn.rs/info.rs/instance_trust.rs). Localizing breaks this. First concrete step: move to typed error kinds/status codes carried out of the client layer (SecretApi currently returns String for all errors), and keep display formatting at the edge (write_error). This also lets us drop the brittle .contains() checks. Lowest ROI on the CLI (technical/English audience); highest on the web frontend (broad reach, mature i18n tooling) — start there if localization becomes a real goal. Other cost drivers if/when pursued: externalizing hundreds of inline strings (esp. cli.rs help text), plural-rules engine (current if n==1 logic is English-only), named-placeholder interpolation for word-order, locale-aware number formatting, and re-baselining string-asserting tests against keys or a pinned locale. Fluent (fluent-rs) is the mature tool but framework-sized vs the repo minimal-dep ethos.",
+        "status": "pending",
+        "priority": "low",
+        "dependencies": [],
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Typed client errors",
+            "description": "Replace SecretApi String errors with a typed error enum carrying HTTP status / error kind; update callers to match on the kind instead of substring-checking the message.",
+            "status": "pending"
+          },
+          {
+            "id": 2,
+            "title": "Audit string-encoded control flow",
+            "description": "Find every .contains() on a display string used for branching and route it through the typed signal.",
+            "status": "pending"
+          }
+        ]
       }
     ]
   }

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+### Changed
+
+- **A 401 on an authenticated command now explains *which* server rejected your key and how to fix it.**
+
+  Instead of `server error (401): unauthorized`, the CLI now prints the
+  same identity block as `secrt auth status` — the masked key with its
+  source, and the server with a `key not recognized` marker — followed by
+  a likely cause and a `secrt auth login` recommendation. The most common
+  trigger is a key that belongs to a different instance than the one
+  you're pointed at.
+
+  - When an explicit `--base-url` points somewhere other than your
+    configured instance, the message names both hosts directly.
+  - The `secrt send --note` pre-check now routes its 401 through the same
+    message rather than a bare `--note: server error (401)`.
+  - `--json` output stays a single terse line.
+
+  Files: `crates/secrt-cli/src/instance_trust.rs`, `crates/secrt-cli/src/auth.rs`.
+
 ## 0.19.0 — 2026-05-28
 
 ### Added

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -21,6 +21,14 @@
 
 ### Changed
 
+- **`secrt config` output is column-aligned and tidier.**
+
+  Effective settings and server limits now line their values up in a column
+  (capped so one long key like `decryption_passphrases` doesn't push everything
+  right — it overflows on its own row instead). `decryption_passphrases` reports
+  a count instead of a row of unreadable masked blobs: `2 entries (config
+  file)`. File: `crates/secrt-cli/src/cli.rs`.
+
 - **Client-side failures no longer masquerade as "server error."**
 
   A 4xx is a problem with the request, not the server, so the CLI now frames

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -9,11 +9,12 @@
   Instead of encrypting, uploading, and *then* getting rejected, the CLI now
   checks the file against the instance's per-secret limit up front (one `/info`
   call) and fails fast in the user's terms: *report.pdf (4 MB) is too large for
-  secrt.ca — it accepts files up to about 48 KB. Sign in with `secrt auth
-  login` to send up to about 1.5 MB.* The budget is derived from the file's
-  actual encryption expansion, so it never contradicts itself near the
-  boundary. Best-effort: if `/info` is unreachable, the upload proceeds and the
-  server still enforces. File: `crates/secrt-cli/src/send.rs`.
+  secrt.ca — it accepts files up to 48 KB. Sign in with `secrt auth login` to
+  send up to 1.5 MB.* The stated budget is derived from the file's actual
+  encryption expansion and rounded down, so it's a ceiling the file is
+  guaranteed to fit under — no hedging. Best-effort: if `/info` is unreachable,
+  the upload proceeds and the server still enforces. File:
+  `crates/secrt-cli/src/send.rs`.
 
 - **`secrt send --file` reports the file name and size on success** — e.g.
   `✓ Encrypted and uploaded report.pdf (119 KB).` (Only for file sends; text

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -32,6 +32,25 @@
 
   Spec: `spec/v1/api.md` §Claim. Files: `crates/secrt-cli/src/get.rs`.
 
+### Fixed
+
+- **A failed save no longer loses an already-retrieved secret.**
+
+  A one-time secret is deleted server-side the instant it's claimed, so the
+  decrypted bytes in memory are the only copy. Previously, if writing them to
+  disk failed (read-only dir, full disk, bad path), `secrt get` printed an
+  error and exited — the secret was gone for good.
+
+  - **`--output <path>` is now pre-flighted before claiming.** If the target
+    isn't writable, `get` fails *without* consuming the secret, so you can fix
+    the path and retry: *can't write to … — the secret was not retrieved.*
+  - **Auto-save failures fall back like a browser.** When saving to the
+    current directory fails, `get` retries the OS Downloads folder, then your
+    home directory, then the temp dir, and reports where it landed — rather
+    than dropping the only copy.
+
+  Files: `crates/secrt-cli/src/get.rs`, `crates/secrt-cli/src/fileutil.rs`.
+
 ## 0.19.0 — 2026-05-28
 
 ### Added

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -17,13 +17,14 @@
 
   Instead of encrypting, uploading, and *then* getting rejected, the CLI now
   checks the file against the instance's per-secret limit up front (one `/info`
-  call) and fails fast in the user's terms: *report.pdf (4 MB) is too large for
-  secrt.ca — it accepts files up to 48 KB. Sign in with `secrt auth login` to
-  send up to 1.5 MB.* The stated budget is derived from the file's actual
-  encryption expansion and rounded down, so it's a ceiling the file is
-  guaranteed to fit under — no hedging. Best-effort: if `/info` is unreachable,
-  the upload proceeds and the server still enforces. File:
-  `crates/secrt-cli/src/send.rs`.
+  call) and fails fast in the user's terms — for example: *“report.pdf is too
+  large for this instance — it accepts files up to ⟨limit⟩. Sign in with `secrt
+  auth login` to send up to ⟨higher limit⟩.”* The actual ceilings are
+  instance-configured and differ for signed-in users, so the message reads them
+  live from `/info`; the stated budget is derived from the file's real
+  encryption expansion and rounded down, so it's a size the file is guaranteed
+  to fit under — no hedging. Best-effort: if `/info` is unreachable, the upload
+  proceeds and the server still enforces. File: `crates/secrt-cli/src/send.rs`.
 
 - **`secrt send --file` reports the file name and size on success** — e.g.
   `✓ Encrypted and uploaded report.pdf (119 KB).` (Only for file sends; text

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Added
+
+- **`secrt send --file` rejects an oversized file before uploading.**
+
+  Instead of encrypting, uploading, and *then* getting rejected, the CLI now
+  checks the file against the instance's per-secret limit up front (one `/info`
+  call) and fails fast in the user's terms: *report.pdf (4 MB) is too large for
+  secrt.ca — it accepts files up to about 48 KB. Sign in with `secrt auth
+  login` to send up to about 1.5 MB.* The budget is derived from the file's
+  actual encryption expansion, so it never contradicts itself near the
+  boundary. Best-effort: if `/info` is unreachable, the upload proceeds and the
+  server still enforces. File: `crates/secrt-cli/src/send.rs`.
+
+- **`secrt send --file` reports the file name and size on success** — e.g.
+  `✓ Encrypted and uploaded report.pdf (119 KB).` (Only for file sends; text
+  and generated secrets stay generic.)
+
 ### Changed
 
 - **Client-side failures no longer masquerade as "server error."**

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -21,6 +21,17 @@
 
   Files: `crates/secrt-cli/src/instance_trust.rs`, `crates/secrt-cli/src/auth.rs`.
 
+- **A claimed/expired/unknown secret now reads as "Secret unavailable," not "server error (404)."**
+
+  The server returns an indistinguishable 404 for expired, already-opened,
+  unknown, and bad-link cases — a deliberate zero-knowledge property, so the
+  CLI can't tell which. Instead of leaking the raw status, `secrt get` now
+  explains the union calmly: *Secret unavailable. It may have already been
+  opened, expired, or the link is incomplete.* Other claim failures (5xx,
+  network, rate limit) keep their explanatory prefix.
+
+  Spec: `spec/v1/api.md` §Claim. Files: `crates/secrt-cli/src/get.rs`.
+
 ## 0.19.0 — 2026-05-28
 
 ### Added

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Security
+
+- **Recovered secret files are written owner-only (`0600`) on Unix.**
+
+  `secrt get` saves decrypted plaintext — including via the new rescue path,
+  which can land in shared `~/Downloads` or `$TMPDIR` — with `0600` instead of
+  whatever the process umask allowed, so a recovered secret isn't left
+  group/world-readable. File: `crates/secrt-cli/src/get.rs`.
+
 ### Added
 
 - **`secrt send --file` rejects an oversized file before uploading.**

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Changed
 
+- **Client-side failures no longer masquerade as "server error."**
+
+  A 4xx is a problem with the request, not the server, so the CLI now frames
+  it that way: `unauthorized (401)`, `forbidden (403)`, `not found (404)`,
+  `rate limit exceeded (429)…`. "server error" is reserved for 5xx, where it's
+  accurate. Redundant `burn failed:` / `list failed:` / `get failed:` prefixes
+  were dropped — the messages now stand on their own. Files: `client.rs`,
+  `burn.rs`, `info.rs`, `list.rs`, `sync.rs`, `get.rs`.
+
+- **A wrong or truncated link gives an actionable hint, not "decryption failed."**
+
+  When a share link decrypts with no passphrase involved, the cause is almost
+  always a `#…` fragment truncated in chat/email — so the message now says so:
+  *the secret key in the link (after #) is wrong or incomplete.* File: `get.rs`.
+
 - **A 401 on an authenticated command now explains *which* server rejected your key and how to fix it.**
 
   Instead of `server error (401): unauthorized`, the CLI now prints the

--- a/crates/secrt-cli/CHANGELOG.md
+++ b/crates/secrt-cli/CHANGELOG.md
@@ -21,6 +21,12 @@
 
   Files: `crates/secrt-cli/src/instance_trust.rs`, `crates/secrt-cli/src/auth.rs`.
 
+- **`secrt get` reports a saved file's size in human-readable units.**
+
+  The save confirmation now shows `119 KB` / `1.2 MB` (base-1000, like a
+  browser) instead of a raw byte count. `--json` still carries exact bytes
+  for machines. Files: `crates/secrt-cli/src/fileutil.rs`.
+
 - **A claimed/expired/unknown secret now reads as "Secret unavailable," not "server error (404)."**
 
   The server returns an indistinguishable 404 for expired, already-opened,

--- a/crates/secrt-cli/src/auth.rs
+++ b/crates/secrt-cli/src/auth.rs
@@ -791,12 +791,16 @@ pub fn fmt_server_line(
     is_tty: bool,
 ) -> String {
     let c = color_func(is_tty);
+    // Strip any URL `#fragment` before display — a base URL shouldn't carry
+    // one, but the fragment is where share links keep secret key material, so
+    // never risk echoing it (see the "never log fragments" non-negotiable).
+    let safe_base_url = base_url.split('#').next().unwrap_or(base_url);
     // The host value is left plain (white) to match the masked key value in
     // `fmt_key_line` — only the label and the parenthetical state are tinted.
     format!(
         "  {}: {} {}\n",
         c(label_color, "Server"),
-        base_url,
+        safe_base_url,
         c(state_color, &format!("({})", state))
     )
 }

--- a/crates/secrt-cli/src/auth.rs
+++ b/crates/secrt-cli/src/auth.rs
@@ -632,12 +632,10 @@ fn run_auth_status(args: &[String], deps: &mut Deps) -> i32 {
     }
 
     let masked = crate::config::mask_secret(&api_key, true);
-    let _ = writeln!(
+    let _ = write!(
         deps.stderr,
-        "  {}: {} {}",
-        c(OPT, "Key"),
-        masked,
-        c(DIM, &format!("(from: {})", source))
+        "{}",
+        fmt_key_line(&masked, source, OPT, (deps.is_tty)())
     );
 
     // Check server connectivity
@@ -650,22 +648,18 @@ fn run_auth_status(args: &[String], deps: &mut Deps) -> i32 {
             } else {
                 "connected, key not recognized"
             };
-            let _ = writeln!(
+            let _ = write!(
                 deps.stderr,
-                "  {}: {} {}",
-                c(OPT, "Server"),
-                c(DIM, &base_url),
-                c(SUCCESS, &format!("({})", status))
+                "{}",
+                fmt_server_line(&base_url, status, OPT, SUCCESS, (deps.is_tty)())
             );
             true
         }
         Err(_) => {
-            let _ = writeln!(
+            let _ = write!(
                 deps.stderr,
-                "  {}: {} {}",
-                c(OPT, "Server"),
-                c(DIM, &base_url),
-                c(DIM, "(unreachable)")
+                "{}",
+                fmt_server_line(&base_url, "unreachable", OPT, DIM, (deps.is_tty)())
             );
             false
         }
@@ -768,6 +762,86 @@ fn resolve_existing_key(deps: &Deps) -> (String, &'static str) {
     } else {
         (String::new(), "")
     }
+}
+
+/// One indented `Key:` line for the auth identity block, matching the
+/// format `secrt auth status` prints. Includes a trailing newline so it can
+/// be concatenated directly into a multi-line message.
+pub fn fmt_key_line(masked_key: &str, source: &str, label_color: &str, is_tty: bool) -> String {
+    let c = color_func(is_tty);
+    format!(
+        "  {}: {} {}\n",
+        c(label_color, "Key"),
+        masked_key,
+        c(DIM, &format!("(from: {})", source))
+    )
+}
+
+/// One indented `Server:` line for the auth identity block. `state` is the
+/// parenthetical status label (e.g. "connected, authenticated", "key not
+/// recognized"). `label_color` tints the `Server` label (yellow in the
+/// `auth status` view, dim inside an error block so the failure stays
+/// prominent); `state_color` tints the parenthetical. Includes a trailing
+/// newline.
+pub fn fmt_server_line(
+    base_url: &str,
+    state: &str,
+    label_color: &str,
+    state_color: &str,
+    is_tty: bool,
+) -> String {
+    let c = color_func(is_tty);
+    // The host value is left plain (white) to match the masked key value in
+    // `fmt_key_line` — only the label and the parenthetical state are tinted.
+    format!(
+        "  {}: {} {}\n",
+        c(label_color, "Server"),
+        base_url,
+        c(state_color, &format!("({})", state))
+    )
+}
+
+/// Mask the effective API key and determine which source it came from,
+/// using the same precedence `resolve_globals` applies (flag > env >
+/// keychain > config). Returns `("", "")` when no key is configured.
+///
+/// The source is inferred by comparing `pa.api_key` against each candidate
+/// source rather than threaded through resolution — anything that matches
+/// none of env/keychain/config must have come from `--api-key`.
+pub fn masked_key_and_source(pa: &ParsedArgs, deps: &Deps) -> (String, &'static str) {
+    let key = pa.api_key.trim();
+    if key.is_empty() {
+        return (String::new(), "");
+    }
+    let masked = crate::config::mask_secret(key, true);
+    let config = crate::config::load_config_with(&*deps.getenv, &mut std::io::sink());
+    let source = if (deps.getenv)("SECRET_API_KEY").as_deref() == Some(key) {
+        "env"
+    } else if config.use_keychain.unwrap_or(false)
+        && (deps.get_keychain_secret)("api_key").as_deref() == Some(key)
+    {
+        "keychain"
+    } else if config.api_key.as_deref() == Some(key) {
+        "config"
+    } else {
+        "flag"
+    };
+    (masked, source)
+}
+
+/// Build the user-facing message for an auth failure. Resolves the local
+/// identity (masked key + source) and delegates to the pure formatter
+/// [`crate::instance_trust::decorate_auth_error`]. For non-401 errors the
+/// formatter returns the input unchanged.
+pub fn explain_auth_error(
+    err: &str,
+    pa: &ParsedArgs,
+    deps: &Deps,
+    json: bool,
+    is_stderr_tty: bool,
+) -> String {
+    let (masked, source) = masked_key_and_source(pa, deps);
+    crate::instance_trust::decorate_auth_error(err, pa, &masked, source, json, is_stderr_tty)
 }
 
 /// Check if the user is already authenticated and prompt for confirmation.

--- a/crates/secrt-cli/src/burn.rs
+++ b/crates/secrt-cli/src/burn.rs
@@ -141,7 +141,7 @@ pub fn run_burn(args: &[String], deps: &mut Deps) -> i32 {
             }
         }
         Err(e) => {
-            let decorated = crate::instance_trust::decorate_auth_error(&e, &pa, stderr_tty);
+            let decorated = crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty);
             write_error(
                 &mut deps.stderr,
                 pa.json,

--- a/crates/secrt-cli/src/burn.rs
+++ b/crates/secrt-cli/src/burn.rs
@@ -120,34 +120,19 @@ pub fn run_burn(args: &[String], deps: &mut Deps) -> i32 {
             match resolve_prefix(client.as_ref(), &secret_id) {
                 Ok(full_id) => {
                     if let Err(e2) = client.burn(&full_id) {
-                        write_error(
-                            &mut deps.stderr,
-                            pa.json,
-                            (deps.is_tty)(),
-                            &format!("burn failed: {}", e2),
-                        );
+                        write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &e2);
                         return 1;
                     }
                 }
                 Err(resolve_err) => {
-                    write_error(
-                        &mut deps.stderr,
-                        pa.json,
-                        (deps.is_tty)(),
-                        &format!("burn failed: {}", resolve_err),
-                    );
+                    write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &resolve_err);
                     return 1;
                 }
             }
         }
         Err(e) => {
             let decorated = crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty);
-            write_error(
-                &mut deps.stderr,
-                pa.json,
-                (deps.is_tty)(),
-                &format!("burn failed: {}", decorated),
-            );
+            write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &decorated);
             return 1;
         }
     }

--- a/crates/secrt-cli/src/cli.rs
+++ b/crates/secrt-cli/src/cli.rs
@@ -920,8 +920,8 @@ fn run_config_show(deps: &mut Deps) -> i32 {
 
     let use_kc = config.use_keychain.unwrap_or(false);
 
-    let _ = writeln!(deps.stderr);
-    let _ = writeln!(deps.stderr, "{}", c(HEADING, "EFFECTIVE SETTINGS"));
+    // Resolve every effective setting's (value, source) up front so the whole
+    // block can be column-aligned in a single pass via `write_setting_rows`.
 
     // use_keychain: config/default
     let (use_kc_val, use_kc_src) = if let Some(v) = config.use_keychain {
@@ -929,13 +929,6 @@ fn run_config_show(deps: &mut Deps) -> i32 {
     } else {
         ("false".into(), "default")
     };
-    let _ = writeln!(
-        deps.stderr,
-        "  {}: {} {}",
-        c(OPT, "use_keychain"),
-        use_kc_val,
-        c(DIM, &format!("({})", use_kc_src)),
-    );
 
     // base_url: flag/env/config/default
     let (base_url_val, base_url_src) = if let Some(env) = (deps.getenv)("SECRET_BASE_URL") {
@@ -945,13 +938,6 @@ fn run_config_show(deps: &mut Deps) -> i32 {
     } else {
         (DEFAULT_BASE_URL.into(), "default")
     };
-    let _ = writeln!(
-        deps.stderr,
-        "  {}: {} {}",
-        c(OPT, "base_url"),
-        base_url_val,
-        c(DIM, &format!("({})", base_url_src)),
-    );
 
     // api_key: env/keychain/config/none
     let (api_key_display, api_key_src) = if let Some(env) = (deps.getenv)("SECRET_API_KEY") {
@@ -969,22 +955,6 @@ fn run_config_show(deps: &mut Deps) -> i32 {
     } else {
         ("(not set)".into(), "")
     };
-    if api_key_src.is_empty() {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {}",
-            c(OPT, "api_key"),
-            c(DIM, &api_key_display),
-        );
-    } else {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {}",
-            c(OPT, "api_key"),
-            api_key_display,
-            c(DIM, &format!("({})", api_key_src)),
-        );
-    }
 
     // passphrase: keychain/config/none
     let (pass_display, pass_src) = if use_kc {
@@ -1000,65 +970,32 @@ fn run_config_show(deps: &mut Deps) -> i32 {
     } else {
         ("(not set)".into(), "")
     };
-    if pass_src.is_empty() {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {}",
-            c(OPT, "passphrase"),
-            c(DIM, &pass_display),
-        );
-    } else {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {}",
-            c(OPT, "passphrase"),
-            pass_display,
-            c(DIM, &format!("({})", pass_src)),
-        );
-    }
 
-    // Fetch server info (best-effort, non-fatal)
+    // Fetch server info (best-effort, non-fatal) — needed for default_ttl here
+    // and the SERVER LIMITS section below.
     let api_key_for_info = if let Some(env) = (deps.getenv)("SECRET_API_KEY") {
         env
     } else if use_kc {
-        if let Some(val) = (deps.get_keychain_secret)("api_key") {
-            val
-        } else {
-            config.api_key.clone().unwrap_or_default()
-        }
-    } else if let Some(ref key) = config.api_key {
-        key.clone()
+        (deps.get_keychain_secret)("api_key")
+            .or_else(|| config.api_key.clone())
+            .unwrap_or_default()
     } else {
-        String::new()
+        config.api_key.clone().unwrap_or_default()
     };
     let api = (deps.make_api)(&base_url_val, &api_key_for_info);
     let server_info = api.info().ok();
 
-    // default_ttl: config/server default
-    if let Some(ref ttl) = config.default_ttl {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {}",
-            c(OPT, "default_ttl"),
-            ttl,
-            c(DIM, "(config file)"),
-        );
+    // default_ttl: config/server default/unknown
+    let (ttl_val, ttl_src): (String, Option<String>) = if let Some(ref ttl) = config.default_ttl {
+        (ttl.clone(), Some("config file".into()))
     } else if let Some(ref info) = server_info {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {}",
-            c(OPT, "default_ttl"),
+        (
             format_ttl_seconds(info.ttl.default_seconds),
-            c(DIM, "(server default)"),
-        );
+            Some("server default".into()),
+        )
     } else {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {}",
-            c(OPT, "default_ttl"),
-            c(DIM, "server default"),
-        );
-    }
+        (c(DIM, "server default"), None)
+    };
 
     // show_input: config/default
     let (show_val, show_src) = if let Some(show) = config.show_input {
@@ -1066,13 +1003,6 @@ fn run_config_show(deps: &mut Deps) -> i32 {
     } else {
         ("false".into(), "default")
     };
-    let _ = writeln!(
-        deps.stderr,
-        "  {}: {} {}",
-        c(OPT, "show_input"),
-        show_val,
-        c(DIM, &format!("({})", show_src)),
-    );
 
     // update_check: env / config / default
     let (uc_val, uc_src) = if let Some(env) = (deps.getenv)("SECRET_NO_UPDATE_CHECK") {
@@ -1088,13 +1018,6 @@ fn run_config_show(deps: &mut Deps) -> i32 {
     } else {
         ("true".into(), "default")
     };
-    let _ = writeln!(
-        deps.stderr,
-        "  {}: {} {}",
-        c(OPT, "update_check"),
-        uc_val,
-        c(DIM, &format!("({})", uc_src)),
-    );
 
     // decryption_passphrases: keychain/config/both/none
     let kc_list = if use_kc {
@@ -1105,36 +1028,57 @@ fn run_config_show(deps: &mut Deps) -> i32 {
     let cfg_list = &config.decryption_passphrases;
     let has_kc = !kc_list.is_empty();
     let has_cfg = !cfg_list.is_empty();
-    if !has_kc && !has_cfg {
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {}",
-            c(OPT, "decryption_passphrases"),
-            c(DIM, "(not set)"),
-        );
+    let (dp_val, dp_src): (String, Option<String>) = if !has_kc && !has_cfg {
+        (c(DIM, "(not set)"), None)
     } else {
-        // Merge for display: keychain first, then config (deduped)
+        // The passphrases are masked and unreadable, so listing them is noise —
+        // report the deduped count (keychain first, then config) and the source.
         let mut merged = kc_list.clone();
         for p in cfg_list {
             if !merged.contains(p) {
                 merged.push(p.clone());
             }
         }
-        let masked = crate::config::mask_secret_list(&merged);
         let src = match (has_kc, has_cfg) {
             (true, true) => "keychain + config file",
             (true, false) => "keychain",
             (false, true) => "config file",
             (false, false) => unreachable!(),
         };
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {}",
-            c(OPT, "decryption_passphrases"),
-            masked,
-            c(DIM, &format!("({} entries, {})", merged.len(), src)),
-        );
-    }
+        let n = merged.len();
+        (
+            format!("{} entr{}", n, if n == 1 { "y" } else { "ies" }),
+            Some(src.to_string()),
+        )
+    };
+
+    // A value-specific dim is baked in for "(not set)" rows (no separate
+    // source); everything else passes a plain value + a parenthesized source.
+    let opt_src = |s: &str| (!s.is_empty()).then(|| s.to_string());
+    let api_key_value = if api_key_src.is_empty() {
+        c(DIM, &api_key_display)
+    } else {
+        api_key_display
+    };
+    let pass_value = if pass_src.is_empty() {
+        c(DIM, &pass_display)
+    } else {
+        pass_display
+    };
+
+    let _ = writeln!(deps.stderr);
+    let _ = writeln!(deps.stderr, "{}", c(HEADING, "EFFECTIVE SETTINGS"));
+    let settings: Vec<(&str, String, Option<String>)> = vec![
+        ("use_keychain", use_kc_val, Some(use_kc_src.into())),
+        ("base_url", base_url_val.clone(), Some(base_url_src.into())),
+        ("api_key", api_key_value, opt_src(api_key_src)),
+        ("passphrase", pass_value, opt_src(pass_src)),
+        ("default_ttl", ttl_val, ttl_src),
+        ("show_input", show_val, Some(show_src.into())),
+        ("update_check", uc_val, Some(uc_src.into())),
+        ("decryption_passphrases", dp_val, dp_src),
+    ];
+    write_setting_rows(&mut deps.stderr, &c, &settings);
 
     // SERVER LIMITS section
     let _ = writeln!(deps.stderr);
@@ -1144,27 +1088,6 @@ fn run_config_show(deps: &mut Deps) -> i32 {
             "{} {}",
             c(HEADING, "SERVER LIMITS"),
             c(DIM, &format!("(from {})", base_url_val)),
-        );
-
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {}",
-            c(OPT, "default_ttl"),
-            format_ttl_seconds(info.ttl.default_seconds),
-            c(DIM, &format!("({}s)", info.ttl.default_seconds)),
-        );
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {}",
-            c(OPT, "max_ttl"),
-            format_ttl_seconds(info.ttl.max_seconds),
-            c(DIM, &format!("({}s)", info.ttl.max_seconds)),
-        );
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {}",
-            c(OPT, "authenticated"),
-            if info.authenticated { "yes" } else { "no" },
         );
 
         let has_key = !api_key_for_info.is_empty();
@@ -1178,52 +1101,67 @@ fn run_config_show(deps: &mut Deps) -> i32 {
         } else {
             ("public", "authed")
         };
+        // Both tiers as one value: "<primary> (label) / <secondary> (label)".
+        let two_tier = |p: String, s: String| {
+            format!(
+                "{} {} / {} {}",
+                p,
+                c(DIM, &format!("({primary_label})")),
+                s,
+                c(DIM, &format!("({secondary_label})")),
+            )
+        };
+        let rate =
+            |r: &crate::client::InfoRate| format!("{}/s burst {}", r.requests_per_second, r.burst);
 
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {} / {} {}",
-            c(OPT, "max_envelope"),
-            format_bytes(primary.max_envelope_bytes),
-            c(DIM, &format!("({})", primary_label)),
-            format_bytes(secondary.max_envelope_bytes),
-            c(DIM, &format!("({})", secondary_label)),
-        );
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {} / {} {}",
-            c(OPT, "max_secrets"),
-            format_limit(primary.max_secrets),
-            c(DIM, &format!("({})", primary_label)),
-            format_limit(secondary.max_secrets),
-            c(DIM, &format!("({})", secondary_label)),
-        );
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {} {} / {} {}",
-            c(OPT, "max_total"),
-            format_bytes(primary.max_total_bytes),
-            c(DIM, &format!("({})", primary_label)),
-            format_bytes(secondary.max_total_bytes),
-            c(DIM, &format!("({})", secondary_label)),
-        );
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {}/s burst {} {} / {}/s burst {} {}",
-            c(OPT, "create_rate"),
-            primary.rate.requests_per_second,
-            primary.rate.burst,
-            c(DIM, &format!("({})", primary_label)),
-            secondary.rate.requests_per_second,
-            secondary.rate.burst,
-            c(DIM, &format!("({})", secondary_label)),
-        );
-        let _ = writeln!(
-            deps.stderr,
-            "  {}: {}/s burst {}",
-            c(OPT, "claim_rate"),
-            info.claim_rate.requests_per_second,
-            info.claim_rate.burst,
-        );
+        let limits: Vec<(&str, String, Option<String>)> = vec![
+            (
+                "default_ttl",
+                format_ttl_seconds(info.ttl.default_seconds),
+                Some(format!("{}s", info.ttl.default_seconds)),
+            ),
+            (
+                "max_ttl",
+                format_ttl_seconds(info.ttl.max_seconds),
+                Some(format!("{}s", info.ttl.max_seconds)),
+            ),
+            (
+                "authenticated",
+                (if info.authenticated { "yes" } else { "no" }).into(),
+                None,
+            ),
+            (
+                "max_envelope",
+                two_tier(
+                    format_bytes(primary.max_envelope_bytes),
+                    format_bytes(secondary.max_envelope_bytes),
+                ),
+                None,
+            ),
+            (
+                "max_secrets",
+                two_tier(
+                    format_limit(primary.max_secrets),
+                    format_limit(secondary.max_secrets),
+                ),
+                None,
+            ),
+            (
+                "max_total",
+                two_tier(
+                    format_bytes(primary.max_total_bytes),
+                    format_bytes(secondary.max_total_bytes),
+                ),
+                None,
+            ),
+            (
+                "create_rate",
+                two_tier(rate(&primary.rate), rate(&secondary.rate)),
+                None,
+            ),
+            ("claim_rate", rate(&info.claim_rate), None),
+        ];
+        write_setting_rows(&mut deps.stderr, &c, &limits);
     } else {
         let _ = writeln!(
             deps.stderr,
@@ -1259,6 +1197,44 @@ pub(crate) fn write_option_rows(w: &mut dyn Write, c: &ColorFn, rows: &[(&str, &
             let _ = writeln!(w, "  {}{:pad$}{}", c(OPT, flags), "", desc);
         } else {
             let _ = writeln!(w, "  {} {}{:pad$}{}", c(OPT, flags), c(ARG, arg), "", desc);
+        }
+    }
+}
+
+/// Write column-aligned `key: value (source)` rows for `secrt config`. Values
+/// align to the longest key that fits within `CAP`; a longer key (e.g.
+/// `decryption_passphrases`) overflows on its own row rather than dragging
+/// every value to the right. `source`, when `Some`, is dimmed and parenthesized;
+/// rows with a value-baked-in dim (e.g. "(not set)") pass `None`. Width is
+/// measured on the plain key — ANSI escapes don't affect column count.
+fn write_setting_rows(w: &mut dyn Write, c: &ColorFn, rows: &[(&str, String, Option<String>)]) {
+    const CAP: usize = 18;
+    let col = rows
+        .iter()
+        .map(|(k, ..)| k.len())
+        .filter(|&l| l <= CAP)
+        .max()
+        .unwrap_or(0);
+    for (key, value, source) in rows {
+        let pad = if key.len() <= col {
+            col - key.len() + 1
+        } else {
+            1
+        };
+        match source {
+            Some(src) => {
+                let _ = writeln!(
+                    w,
+                    "  {}:{:pad$}{} {}",
+                    c(OPT, key),
+                    "",
+                    value,
+                    c(DIM, &format!("({src})")),
+                );
+            }
+            None => {
+                let _ = writeln!(w, "  {}:{:pad$}{}", c(OPT, key), "", value);
+            }
         }
     }
 }

--- a/crates/secrt-cli/src/client.rs
+++ b/crates/secrt-cli/src/client.rs
@@ -179,28 +179,37 @@ impl ApiClient {
 
 /// Friendly fallback error message for HTTP status codes when the server
 /// provides no JSON error body.
+///
+/// "server error" is reserved for 5xx — the cases that are genuinely the
+/// server's fault. 4xx are client-side conditions (bad key, gone secret,
+/// too many requests), so they're framed as the condition itself. Every
+/// message keeps the `(status)` suffix so callers that detect codes by
+/// substring (`(401)`, `404`) keep working.
 fn format_status_error(status: u16) -> String {
-    let desc = match status {
-        401 => "unauthorized; check your API key",
-        403 => "forbidden",
-        404 => "not found",
-        429 => "rate limit exceeded; please try again in a few seconds",
-        500 | 502 | 503 => "server is temporarily unavailable; please try again later",
-        _ => "",
-    };
-    if desc.is_empty() {
-        format!("server error ({})", status)
-    } else {
-        format!("server error ({}): {}", status, desc)
+    match status {
+        401 => "unauthorized (401); check your API key".to_string(),
+        403 => "forbidden (403)".to_string(),
+        404 => "not found (404)".to_string(),
+        429 => "rate limit exceeded (429); please try again in a few seconds".to_string(),
+        500 | 502 | 503 => {
+            format!("the server is temporarily unavailable ({status}); please try again later")
+        }
+        s if s >= 500 => format!("server error ({s})"),
+        s => format!("request failed ({s})"),
     }
 }
 
-/// Format an API error from a JSON body and status code.
-/// Returns `None` if the body doesn't contain a valid error message.
+/// Format an API error from a JSON body and status code. A server-provided
+/// message is surfaced verbatim with the status appended; only 5xx keeps the
+/// "server error" framing (4xx are client-side conditions).
 fn format_api_error(status: u16, body: &str) -> String {
     if let Ok(err_resp) = serde_json::from_str::<ApiErrorResponse>(body) {
         if !err_resp.error.is_empty() {
-            return format!("server error ({}): {}", status, err_resp.error);
+            return if status >= 500 {
+                format!("server error ({}): {}", status, err_resp.error)
+            } else {
+                format!("{} ({})", err_resp.error, status)
+            };
         }
     }
     format_status_error(status)
@@ -912,78 +921,83 @@ mod tests {
         let msg = format_status_error(429);
         assert_eq!(
             msg,
-            "server error (429): rate limit exceeded; please try again in a few seconds"
+            "rate limit exceeded (429); please try again in a few seconds"
         );
     }
 
     #[test]
     fn status_401_unauthorized() {
+        // 4xx is a client-side condition — not framed as a "server error" —
+        // but keeps the "(401)" marker the auth-error decorator detects.
         let msg = format_status_error(401);
-        assert_eq!(msg, "server error (401): unauthorized; check your API key");
+        assert_eq!(msg, "unauthorized (401); check your API key");
+        assert!(msg.contains("(401)"));
     }
 
     #[test]
     fn status_403_forbidden() {
-        let msg = format_status_error(403);
-        assert_eq!(msg, "server error (403): forbidden");
+        assert_eq!(format_status_error(403), "forbidden (403)");
     }
 
     #[test]
     fn status_404_not_found() {
         let msg = format_status_error(404);
-        assert_eq!(msg, "server error (404): not found");
+        assert_eq!(msg, "not found (404)");
+        assert!(msg.contains("404"));
     }
 
     #[test]
     fn status_500_unavailable() {
-        let msg = format_status_error(500);
         assert_eq!(
-            msg,
-            "server error (500): server is temporarily unavailable; please try again later"
+            format_status_error(500),
+            "the server is temporarily unavailable (500); please try again later"
         );
     }
 
     #[test]
     fn status_502_unavailable() {
-        let msg = format_status_error(502);
         assert_eq!(
-            msg,
-            "server error (502): server is temporarily unavailable; please try again later"
+            format_status_error(502),
+            "the server is temporarily unavailable (502); please try again later"
         );
     }
 
     #[test]
     fn status_503_unavailable() {
-        let msg = format_status_error(503);
         assert_eq!(
-            msg,
-            "server error (503): server is temporarily unavailable; please try again later"
+            format_status_error(503),
+            "the server is temporarily unavailable (503); please try again later"
         );
     }
 
     #[test]
-    fn status_unknown_code() {
-        let msg = format_status_error(418);
-        assert_eq!(msg, "server error (418)");
+    fn status_unknown_5xx_is_server_error() {
+        assert_eq!(format_status_error(599), "server error (599)");
+    }
+
+    #[test]
+    fn status_unknown_4xx_is_request_failed() {
+        // "server error" is reserved for 5xx; an odd 4xx is a request failure.
+        assert_eq!(format_status_error(418), "request failed (418)");
     }
 
     // --- format_api_error: JSON body parsing + fallback ---
 
     #[test]
-    fn api_error_json_body() {
+    fn api_error_json_body_4xx_drops_server_error_framing() {
         let body = r#"{"error":"rate limit exceeded; please try again in a few seconds"}"#;
         let msg = format_api_error(429, body);
         assert_eq!(
             msg,
-            "server error (429): rate limit exceeded; please try again in a few seconds"
+            "rate limit exceeded; please try again in a few seconds (429)"
         );
     }
 
     #[test]
-    fn api_error_custom_message() {
+    fn api_error_custom_message_4xx() {
         let body = r#"{"error":"quota exceeded for your plan"}"#;
         let msg = format_api_error(429, body);
-        assert_eq!(msg, "server error (429): quota exceeded for your plan");
+        assert_eq!(msg, "quota exceeded for your plan (429)");
     }
 
     #[test]
@@ -992,7 +1006,7 @@ mod tests {
         let msg = format_api_error(429, body);
         assert_eq!(
             msg,
-            "server error (429): rate limit exceeded; please try again in a few seconds"
+            "rate limit exceeded (429); please try again in a few seconds"
         );
     }
 
@@ -1001,7 +1015,7 @@ mod tests {
         let msg = format_api_error(429, "not json");
         assert_eq!(
             msg,
-            "server error (429): rate limit exceeded; please try again in a few seconds"
+            "rate limit exceeded (429); please try again in a few seconds"
         );
     }
 
@@ -1010,18 +1024,17 @@ mod tests {
         let msg = format_api_error(429, "");
         assert_eq!(
             msg,
-            "server error (429): rate limit exceeded; please try again in a few seconds"
+            "rate limit exceeded (429); please try again in a few seconds"
         );
     }
 
     #[test]
     fn api_error_unknown_status_no_json() {
-        let msg = format_api_error(418, "");
-        assert_eq!(msg, "server error (418)");
+        assert_eq!(format_api_error(418, ""), "request failed (418)");
     }
 
     #[test]
-    fn api_error_server_message_overrides_fallback() {
+    fn api_error_5xx_keeps_server_error_framing() {
         let body = r#"{"error":"custom server message"}"#;
         let msg = format_api_error(500, body);
         assert_eq!(msg, "server error (500): custom server message");

--- a/crates/secrt-cli/src/fileutil.rs
+++ b/crates/secrt-cli/src/fileutil.rs
@@ -107,6 +107,50 @@ pub fn resolve_output_path(filename: &str) -> Result<PathBuf, String> {
     ))
 }
 
+/// Confirm we can write to `path` *before* claiming a one-time secret, so a
+/// secret is never consumed when we already know we can't deliver it.
+///
+/// For an existing target, opens it for writing (no truncation) to test
+/// overwrite permission. For a new target, creates and removes a throwaway
+/// probe file in the parent directory so the real target is left untouched.
+/// Returns a human-readable reason on failure.
+pub fn preflight_writable(path: &str) -> Result<(), String> {
+    use std::fs::{self, OpenOptions};
+
+    let target = Path::new(path);
+
+    if target.exists() {
+        if target.is_dir() {
+            return Err(format!("{} is a directory", target.display()));
+        }
+        return OpenOptions::new()
+            .write(true)
+            .open(target)
+            .map(|_| ())
+            .map_err(|e| e.to_string());
+    }
+
+    let dir = match target.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
+    if !dir.exists() {
+        return Err(format!("no such directory: {}", dir.display()));
+    }
+
+    let probe = dir.join(format!(".secrt-write-probe-{}", std::process::id()));
+    match OpenOptions::new().write(true).create_new(true).open(&probe) {
+        Ok(_) => {
+            let _ = fs::remove_file(&probe);
+            Ok(())
+        }
+        // The probe already existing means the directory accepts new files,
+        // which is exactly what we're testing for.
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
 /// Extract a `FileHint` from decrypted payload metadata.
 ///
 /// Returns `Some(FileHint)` only when `metadata.type == "file"` and the
@@ -130,6 +174,41 @@ pub fn extract_file_hint(metadata: &PayloadMeta) -> Option<FileHint> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- preflight_writable ---
+
+    #[test]
+    fn preflight_ok_for_new_file_leaves_no_probe() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("out.txt");
+        assert!(preflight_writable(target.to_str().unwrap()).is_ok());
+        assert!(!target.exists(), "preflight must not create the target");
+        // No probe file should be left behind in the directory.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+        assert!(leftovers.is_empty(), "probe file leaked: {leftovers:?}");
+    }
+
+    #[test]
+    fn preflight_err_for_missing_directory() {
+        let err = preflight_writable("/nonexistent-secrt-dir-xyz/out.txt").unwrap_err();
+        assert!(err.contains("no such directory"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preflight_err_for_readonly_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let set = |mode: u32| {
+            let mut p = std::fs::metadata(dir.path()).unwrap().permissions();
+            p.set_mode(mode);
+            std::fs::set_permissions(dir.path(), p).unwrap();
+        };
+        set(0o555); // r-x: can enter, cannot create
+        let res = preflight_writable(dir.path().join("out.txt").to_str().unwrap());
+        set(0o755); // restore so tempdir cleanup works
+        assert!(res.is_err(), "read-only dir should fail preflight");
+    }
 
     // --- build_file_metadata ---
 

--- a/crates/secrt-cli/src/fileutil.rs
+++ b/crates/secrt-cli/src/fileutil.rs
@@ -128,6 +128,25 @@ pub(crate) fn human_size(bytes: usize) -> String {
     }
 }
 
+/// Like [`human_size`] but rounds *down*, for stating a ceiling a value is
+/// guaranteed to fit under (e.g. an upload budget). Rounding to nearest would
+/// overstate the ceiling and promise a size that's actually rejected.
+pub(crate) fn human_size_floor(bytes: usize) -> String {
+    const KB: f64 = 1_000.0;
+    const MB: f64 = 1_000_000.0;
+    const GB: f64 = 1_000_000_000.0;
+    let b = bytes as f64;
+    if bytes < 1_000 {
+        format!("{} byte{}", bytes, if bytes == 1 { "" } else { "s" })
+    } else if b < MB {
+        format!("{} KB", (b / KB).floor() as u64)
+    } else if b < GB {
+        format!("{:.1} MB", (b / MB * 10.0).floor() / 10.0)
+    } else {
+        format!("{:.1} GB", (b / GB * 10.0).floor() / 10.0)
+    }
+}
+
 /// Confirm we can write to `path` *before* claiming a one-time secret, so a
 /// secret is never consumed when we already know we can't deliver it.
 ///
@@ -218,6 +237,22 @@ mod tests {
         ];
         for (bytes, want) in cases {
             assert_eq!(human_size(bytes), want, "bytes={bytes}");
+        }
+    }
+
+    #[test]
+    fn human_size_floor_rounds_down() {
+        let cases = [
+            (1_574_000usize, "1.5 MB"), // would round up to 1.6 with human_size
+            (1_600_000, "1.6 MB"),
+            (1_999_999, "1.9 MB"),
+            (999_999, "999 KB"),
+            (1_000_000, "1.0 MB"),
+            (1_500, "1 KB"),
+            (2_500_000_000, "2.5 GB"),
+        ];
+        for (bytes, want) in cases {
+            assert_eq!(human_size_floor(bytes), want, "bytes={bytes}");
         }
     }
 

--- a/crates/secrt-cli/src/fileutil.rs
+++ b/crates/secrt-cli/src/fileutil.rs
@@ -107,6 +107,27 @@ pub fn resolve_output_path(filename: &str) -> Result<PathBuf, String> {
     ))
 }
 
+/// Format a byte count the way a browser or Finder shows a download: base-1000
+/// `KB`/`MB`/`GB`, integer `KB`, one decimal for `MB` and up. For human-facing
+/// display of *arbitrary* sizes (a saved/sent file). Round policy *limits*
+/// (powers of two) use `cli::format_bytes` instead, which renders them exactly
+/// in base-2; `--json` carries exact byte counts for machines.
+pub(crate) fn human_size(bytes: usize) -> String {
+    const KB: f64 = 1_000.0;
+    const MB: f64 = 1_000_000.0;
+    const GB: f64 = 1_000_000_000.0;
+    let b = bytes as f64;
+    if bytes < 1_000 {
+        format!("{} byte{}", bytes, if bytes == 1 { "" } else { "s" })
+    } else if b < MB {
+        format!("{} KB", (b / KB).round() as u64)
+    } else if b < GB {
+        format!("{:.1} MB", b / MB)
+    } else {
+        format!("{:.1} GB", b / GB)
+    }
+}
+
 /// Confirm we can write to `path` *before* claiming a one-time secret, so a
 /// secret is never consumed when we already know we can't deliver it.
 ///
@@ -174,6 +195,31 @@ pub fn extract_file_hint(metadata: &PayloadMeta) -> Option<FileHint> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- human_size ---
+
+    #[test]
+    fn human_size_table() {
+        let cases = [
+            (0usize, "0 bytes"),
+            (1, "1 byte"),
+            (999, "999 bytes"),
+            (1_000, "1 KB"),
+            (1_499, "1 KB"),
+            (1_500, "2 KB"),
+            (119_184, "119 KB"),
+            (999_499, "999 KB"),
+            (1_000_000, "1.0 MB"),
+            (1_200_000, "1.2 MB"),
+            (1_550_000, "1.6 MB"),
+            (999_900_000, "999.9 MB"),
+            (1_000_000_000, "1.0 GB"),
+            (2_500_000_000, "2.5 GB"),
+        ];
+        for (bytes, want) in cases {
+            assert_eq!(human_size(bytes), want, "bytes={bytes}");
+        }
+    }
 
     // --- preflight_writable ---
 

--- a/crates/secrt-cli/src/fileutil.rs
+++ b/crates/secrt-cli/src/fileutil.rs
@@ -178,15 +178,24 @@ pub fn preflight_writable(path: &str) -> Result<(), String> {
         return Err(format!("no such directory: {}", dir.display()));
     }
 
-    let probe = dir.join(format!(".secrt-write-probe-{}", std::process::id()));
+    // Probe with a per-run unique name (pid + timestamp) and require a *fresh*
+    // create — a leftover probe from a crashed run must not count as proof the
+    // directory is writable, or `get --output …` could consume a one-time
+    // secret and then fail on the real write.
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let probe = dir.join(format!(
+        ".secrt-write-probe-{}-{}",
+        std::process::id(),
+        stamp
+    ));
     match OpenOptions::new().write(true).create_new(true).open(&probe) {
         Ok(_) => {
             let _ = fs::remove_file(&probe);
             Ok(())
         }
-        // The probe already existing means the directory accepts new files,
-        // which is exactly what we're testing for.
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
         Err(e) => Err(e.to_string()),
     }
 }

--- a/crates/secrt-cli/src/get.rs
+++ b/crates/secrt-cli/src/get.rs
@@ -137,7 +137,7 @@ pub fn run_get(args: &[String], deps: &mut Deps) -> i32 {
                  or the link is incomplete."
                     .to_string()
             } else {
-                format!("get failed: {}", e)
+                e
             };
             write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &msg);
             return 1;
@@ -283,9 +283,17 @@ pub fn run_get(args: &[String], deps: &mut Deps) -> i32 {
 
         // --- Phase C: Fallback to interactive prompt or error ---
         if !needs_pass && tried == 0 {
-            // No passphrase needed and decryption failed with empty passphrase — this is
-            // a genuine decryption error (wrong URL key), not a passphrase issue
-            write_error(&mut deps.stderr, pa.json, is_tty, "decryption failed");
+            // No passphrase needed and decryption failed with empty passphrase —
+            // a genuine decryption error (wrong URL key). The overwhelmingly
+            // common cause is a link whose `#…` fragment got truncated in
+            // chat/email, so point the recipient at that.
+            write_error(
+                &mut deps.stderr,
+                pa.json,
+                is_tty,
+                "decryption failed — the secret key in the link (after #) is wrong or \
+                 incomplete. Check that you copied the entire link.",
+            );
             return 1;
         }
 

--- a/crates/secrt-cli/src/get.rs
+++ b/crates/secrt-cli/src/get.rs
@@ -546,8 +546,8 @@ fn report_saved(
     }
     let c = color_func((deps.is_tty)());
     let detail = match mime {
-        Some(m) => format!("{}, {} bytes", m, size),
-        None => format!("{} bytes", size),
+        Some(m) => format!("{}, {}", m, crate::fileutil::human_size(size)),
+        None => crate::fileutil::human_size(size),
     };
     let _ = writeln!(
         deps.stderr,

--- a/crates/secrt-cli/src/get.rs
+++ b/crates/secrt-cli/src/get.rs
@@ -106,12 +106,19 @@ pub fn run_get(args: &[String], deps: &mut Deps) -> i32 {
     let resp = match client.claim(&id, &claim_token) {
         Ok(r) => r,
         Err(e) => {
-            write_error(
-                &mut deps.stderr,
-                pa.json,
-                (deps.is_tty)(),
-                &format!("get failed: {}", e),
-            );
+            // The server returns an indistinguishable 404 for expired /
+            // already-claimed / unknown / bad-token (a deliberate
+            // zero-knowledge property — see spec/v1/api.md §Claim). Since we
+            // can't tell which, give the recipient a calm explanation of the
+            // union rather than a raw "server error (404): not found".
+            let msg = if e.contains("(404)") {
+                "Secret unavailable. It may have already been opened, expired, \
+                 or the link is incomplete."
+                    .to_string()
+            } else {
+                format!("get failed: {}", e)
+            };
+            write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &msg);
             return 1;
         }
     };

--- a/crates/secrt-cli/src/get.rs
+++ b/crates/secrt-cli/src/get.rs
@@ -1,12 +1,13 @@
 use std::fs;
 use std::io::Write;
+use std::path::PathBuf;
 
 use crate::cli::{
     derive_base_url_from_url, parse_flags, print_get_help, resolve_globals, CliError, Deps,
 };
 use crate::color::{color_func, DIM, LABEL, SUCCESS, WARN};
 use crate::envelope::{self, EnvelopeError, OpenParams, PayloadMeta};
-use crate::fileutil::{extract_file_hint, resolve_output_path};
+use crate::fileutil::{extract_file_hint, preflight_writable, resolve_output_path};
 use crate::passphrase::{resolve_passphrase, write_error};
 
 pub fn run_get(args: &[String], deps: &mut Deps) -> i32 {
@@ -99,6 +100,26 @@ pub fn run_get(args: &[String], deps: &mut Deps) -> i32 {
             return 1;
         }
     };
+
+    // Pre-flight: when the caller pinned an explicit output file, confirm we
+    // can write it *before* claiming. A one-time secret must not be consumed
+    // if we already know we can't deliver it. (`--output -` is stdout; `--json`
+    // ignores `--output`.)
+    if !pa.json && !pa.output.is_empty() && pa.output != "-" {
+        if let Err(e) = preflight_writable(&pa.output) {
+            write_error(
+                &mut deps.stderr,
+                pa.json,
+                (deps.is_tty)(),
+                &format!(
+                    "can't write to {}: {} — the secret was not retrieved; \
+                     fix the path and try again",
+                    pa.output, e
+                ),
+            );
+            return 1;
+        }
+    }
 
     // Claim from server
     let client = (deps.make_api)(&base_url, &pa.api_key);
@@ -431,7 +452,8 @@ fn output_plaintext(
 
     // 3. --output <path> → write to explicit path
     if !pa.output.is_empty() {
-        return write_file_output(&pa.output, plaintext, None, pa, deps);
+        let filename = clean_filename(&pa.output);
+        return write_file_output(&pa.output, &filename, plaintext, None, pa, deps);
     }
 
     // 4. File hint + stdout is TTY → auto-save
@@ -440,11 +462,25 @@ fn output_plaintext(
             let path = match resolve_output_path(&fh.filename) {
                 Ok(p) => p,
                 Err(e) => {
-                    let _ = writeln!(deps.stderr, "error: {}", e);
-                    return 1;
+                    return rescue_save(
+                        &fh.filename,
+                        &fh.filename,
+                        &e,
+                        plaintext,
+                        Some(&fh.mime),
+                        pa,
+                        deps,
+                    )
                 }
             };
-            return write_file_output(&path.to_string_lossy(), plaintext, Some(&fh.mime), pa, deps);
+            return write_file_output(
+                &path.to_string_lossy(),
+                &fh.filename,
+                plaintext,
+                Some(&fh.mime),
+                pa,
+                deps,
+            );
         }
     }
 
@@ -471,44 +507,182 @@ fn output_plaintext(
             let filename = "secret.bin";
             let path = match resolve_output_path(filename) {
                 Ok(p) => p,
-                Err(e) => {
-                    let _ = writeln!(deps.stderr, "error: {}", e);
-                    return 1;
-                }
+                Err(e) => return rescue_save(filename, filename, &e, plaintext, None, pa, deps),
             };
-            return write_file_output(&path.to_string_lossy(), plaintext, None, pa, deps);
+            return write_file_output(&path.to_string_lossy(), filename, plaintext, None, pa, deps);
         }
     }
     0
 }
 
-/// Write plaintext to a file and show a success message on stderr.
+/// Write plaintext to a file and show a success message on stderr. On write
+/// failure the secret is *already claimed* (consumed server-side), so we never
+/// just error — we hand off to [`rescue_save`] to land it somewhere else.
 fn write_file_output(
     path: &str,
+    filename: &str,
     plaintext: &[u8],
     mime: Option<&str>,
     pa: &crate::cli::ParsedArgs,
     deps: &mut Deps,
 ) -> i32 {
     if let Err(e) = fs::write(path, plaintext) {
-        let _ = writeln!(deps.stderr, "error: write file: {}", e);
-        return 1;
+        return rescue_save(filename, path, &e.to_string(), plaintext, mime, pa, deps);
+    }
+    report_saved(path, plaintext.len(), mime, pa, deps);
+    0
+}
+
+/// Print the "Saved to <path> (<detail>)" confirmation on stderr.
+fn report_saved(
+    path: &str,
+    size: usize,
+    mime: Option<&str>,
+    pa: &crate::cli::ParsedArgs,
+    deps: &mut Deps,
+) {
+    if pa.silent {
+        return;
+    }
+    let c = color_func((deps.is_tty)());
+    let detail = match mime {
+        Some(m) => format!("{}, {} bytes", m, size),
+        None => format!("{} bytes", size),
+    };
+    let _ = writeln!(
+        deps.stderr,
+        "{} Saved to {} ({})",
+        c(SUCCESS, "\u{2713}"),
+        path,
+        c(DIM, &detail),
+    );
+}
+
+/// Ordered fallback directories for a post-claim rescue, mirroring how a
+/// browser handles a download: the OS Downloads folder, then the home
+/// directory, then the temp dir. An explicit `XDG_DOWNLOAD_DIR`/`HOME` env
+/// wins over the platform default (and keeps this testable). `dirs::*` returns
+/// `None` on, e.g., a bare server with no Downloads configured — we simply skip
+/// that rung rather than fabricate a folder.
+fn fallback_dirs(deps: &Deps) -> Vec<PathBuf> {
+    let mut dirs_list = Vec::new();
+
+    match (deps.getenv)("XDG_DOWNLOAD_DIR").filter(|s| !s.is_empty()) {
+        Some(d) => dirs_list.push(PathBuf::from(d)),
+        None => {
+            if let Some(d) = dirs::download_dir() {
+                dirs_list.push(d);
+            }
+        }
     }
 
+    match (deps.getenv)("HOME")
+        .or_else(|| (deps.getenv)("USERPROFILE"))
+        .filter(|s| !s.is_empty())
+    {
+        Some(h) => dirs_list.push(PathBuf::from(h)),
+        None => {
+            if let Some(h) = dirs::home_dir() {
+                dirs_list.push(h);
+            }
+        }
+    }
+
+    dirs_list.push(std::env::temp_dir());
+    dirs_list
+}
+
+/// Last-resort delivery when a file write fails *after* the secret has been
+/// claimed (and so deleted server-side). The in-memory plaintext is the only
+/// copy, so never return without trying to land it somewhere: walk the
+/// fallback chain (Downloads → home → temp), writing to the first that accepts
+/// it and reporting where it went. Errors only if every location fails.
+fn rescue_save(
+    filename: &str,
+    attempted: &str,
+    reason: &str,
+    plaintext: &[u8],
+    mime: Option<&str>,
+    pa: &crate::cli::ParsedArgs,
+    deps: &mut Deps,
+) -> i32 {
     if !pa.silent {
-        let c = color_func((deps.is_tty)());
-        let size = plaintext.len();
-        let detail = match mime {
-            Some(m) => format!("{}, {} bytes", m, size),
-            None => format!("{} bytes", size),
-        };
+        let c = color_func((deps.is_stderr_tty)());
+        // Name the *directory* that failed, not the collision-resolved file
+        // name — "couldn't save rm to /bin" is clearer than "…to rm (1)".
         let _ = writeln!(
             deps.stderr,
-            "{} Saved to {} ({})",
-            c(SUCCESS, "\u{2713}"),
-            path,
-            c(DIM, &detail),
+            "{} couldn't save {} to {}: {}",
+            c(WARN, "!"),
+            filename,
+            failed_location(attempted),
+            reason,
+        );
+        let _ = writeln!(
+            deps.stderr,
+            "  this secret has already been retrieved and can't be fetched again.",
         );
     }
-    0
+
+    for dir in fallback_dirs(deps) {
+        if fs::create_dir_all(&dir).is_err() {
+            continue;
+        }
+        // Re-resolve collisions from the *clean* filename in each fallback dir,
+        // so a suffix earned in one directory doesn't leak into another.
+        let candidate = match resolve_output_path(&dir.join(filename).to_string_lossy()) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if fs::write(&candidate, plaintext).is_ok() {
+            report_saved(
+                &candidate.to_string_lossy(),
+                plaintext.len(),
+                mime,
+                pa,
+                deps,
+            );
+            return 0;
+        }
+    }
+
+    write_error(
+        &mut deps.stderr,
+        pa.json,
+        (deps.is_tty)(),
+        &format!(
+            "couldn't save {} to {} or any fallback location ({}); \
+             it has already been retrieved and cannot be recovered",
+            filename,
+            failed_location(attempted),
+            reason
+        ),
+    );
+    1
+}
+
+/// The basename to reuse when rescuing a write to another directory. Falls
+/// back to `secret.bin` for odd inputs (trailing slash, empty).
+fn clean_filename(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("secret.bin")
+        .to_string()
+}
+
+/// Describe the directory a failed write was aimed at, for the rescue warning.
+/// A bare relative name (e.g. `rm` or `rm (1)`) has no parent, so report the
+/// current working directory instead of an empty string.
+fn failed_location(attempted: &str) -> String {
+    match std::path::Path::new(attempted)
+        .parent()
+        .filter(|d| !d.as_os_str().is_empty())
+    {
+        Some(d) => d.display().to_string(),
+        None => std::env::current_dir()
+            .map(|d| d.display().to_string())
+            .unwrap_or_else(|_| ".".to_string()),
+    }
 }

--- a/crates/secrt-cli/src/get.rs
+++ b/crates/secrt-cli/src/get.rs
@@ -534,11 +534,33 @@ fn write_file_output(
     pa: &crate::cli::ParsedArgs,
     deps: &mut Deps,
 ) -> i32 {
-    if let Err(e) = fs::write(path, plaintext) {
+    if let Err(e) = write_secret_file(std::path::Path::new(path), plaintext) {
         return rescue_save(filename, path, &e.to_string(), plaintext, mime, pa, deps);
     }
-    report_saved(path, plaintext.len(), mime, pa, deps);
+    report_saved(path, plaintext.len(), mime, pa, deps, false);
     0
+}
+
+/// Write decrypted plaintext to disk. On Unix the file is created `0600`
+/// (owner-only) so a recovered secret isn't left group/world-readable — this
+/// matters most for the rescue path, which can land in shared Downloads/temp
+/// directories.
+fn write_secret_file(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        std::io::Write::write_all(&mut f, bytes)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, bytes)
+    }
 }
 
 /// Print the "Saved to <path> (<detail>)" confirmation on stderr.
@@ -548,8 +570,11 @@ fn report_saved(
     mime: Option<&str>,
     pa: &crate::cli::ParsedArgs,
     deps: &mut Deps,
+    force: bool,
 ) {
-    if pa.silent {
+    // A rescue forces the line through even under --silent: the secret landed
+    // somewhere other than asked, and it's the only remaining copy.
+    if pa.silent && !force {
         return;
     }
     let c = color_func((deps.is_tty)());
@@ -614,7 +639,10 @@ fn rescue_save(
     pa: &crate::cli::ParsedArgs,
     deps: &mut Deps,
 ) -> i32 {
-    if !pa.silent {
+    // A post-claim rescue is an exceptional, data-integrity event — always
+    // announce it, even under --silent, so the user knows where the only copy
+    // went and why it's not where they asked.
+    {
         let c = color_func((deps.is_stderr_tty)());
         // Name the *directory* that failed, not the collision-resolved file
         // name — "couldn't save rm to /bin" is clearer than "…to rm (1)".
@@ -642,13 +670,14 @@ fn rescue_save(
             Ok(p) => p,
             Err(_) => continue,
         };
-        if fs::write(&candidate, plaintext).is_ok() {
+        if write_secret_file(&candidate, plaintext).is_ok() {
             report_saved(
                 &candidate.to_string_lossy(),
                 plaintext.len(),
                 mime,
                 pa,
                 deps,
+                true,
             );
             return 0;
         }

--- a/crates/secrt-cli/src/info.rs
+++ b/crates/secrt-cli/src/info.rs
@@ -197,33 +197,18 @@ pub fn run_info(args: &[String], deps: &mut Deps) -> i32 {
             Ok(full_id) => match client.get_secret_metadata(&full_id) {
                 Ok(m) => m,
                 Err(e2) => {
-                    write_error(
-                        &mut deps.stderr,
-                        pa.json,
-                        (deps.is_tty)(),
-                        &format!("info failed: {}", e2),
-                    );
+                    write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &e2);
                     return 1;
                 }
             },
             Err(resolve_err) => {
-                write_error(
-                    &mut deps.stderr,
-                    pa.json,
-                    (deps.is_tty)(),
-                    &format!("info failed: {}", resolve_err),
-                );
+                write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &resolve_err);
                 return 1;
             }
         },
         Err(e) => {
             let decorated = crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty);
-            write_error(
-                &mut deps.stderr,
-                pa.json,
-                (deps.is_tty)(),
-                &format!("info failed: {}", decorated),
-            );
+            write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &decorated);
             return 1;
         }
     };

--- a/crates/secrt-cli/src/info.rs
+++ b/crates/secrt-cli/src/info.rs
@@ -217,7 +217,7 @@ pub fn run_info(args: &[String], deps: &mut Deps) -> i32 {
             }
         },
         Err(e) => {
-            let decorated = crate::instance_trust::decorate_auth_error(&e, &pa, stderr_tty);
+            let decorated = crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty);
             write_error(
                 &mut deps.stderr,
                 pa.json,

--- a/crates/secrt-cli/src/instance_trust.rs
+++ b/crates/secrt-cli/src/instance_trust.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use secrt_core::{classify_origin, host_of, TrustDecision};
 
 use crate::cli::{BaseUrlSource, ParsedArgs};
-use crate::color::{color_func, CMD, ERROR, OPT, URL, WARN};
+use crate::color::{color_func, CMD, DIM, ERROR, OPT, URL, WARN};
 
 /// Emit a loud warning to `stderr` when `base_url` classifies as
 /// `Untrusted`. No-op for `Official`, `TrustedCustom`, and `DevLocal`.
@@ -109,41 +109,93 @@ pub fn block_if_cross_instance(
     Err(2)
 }
 
-/// Decorate a server error string with a host-mismatch hint when a
-/// 401 likely means "your auto-loaded API key is for a different
-/// host," not "your key is invalid." The hint fires when the user
-/// passed an explicit `--base-url` (`Flag` source) AND that host
-/// differs from the one their key was registered against.
+/// Rewrite a 401 server error into an actionable auth-failure message: a
+/// headline naming the host that rejected the key, the same identity block
+/// `secrt auth status` prints (key + source, server + "key not recognized"),
+/// a hypothesis line, and a `secrt auth login` recommendation.
 ///
-/// Returns `err` unchanged when the error isn't a 401, when no flag
-/// was passed, or when the flagged host equals the configured one.
-pub fn decorate_auth_error(err: &str, pa: &ParsedArgs, is_stderr_tty: bool) -> String {
+/// `masked_key`/`key_source` come from [`crate::auth::masked_key_and_source`]
+/// (empty when no key is configured). In `json` mode a single terse line is
+/// returned so machine consumers stay parseable. Non-401 errors pass through
+/// unchanged.
+pub fn decorate_auth_error(
+    err: &str,
+    pa: &ParsedArgs,
+    masked_key: &str,
+    key_source: &str,
+    json: bool,
+    is_stderr_tty: bool,
+) -> String {
     if !err.contains("(401)") {
         return err.to_string();
     }
-    if pa.base_url_source != BaseUrlSource::Flag {
-        return err.to_string();
+    let host = host_of(&pa.base_url).unwrap_or_else(|| pa.base_url.clone());
+    let has_key = !masked_key.is_empty();
+
+    // Machine consumers get one terse, parseable line — no block, no color.
+    if json {
+        return if has_key {
+            format!(
+                "{host} rejected your API key (401); it may be for a different secrt \
+                 instance or was revoked — run `secrt auth login`"
+            )
+        } else {
+            format!("{host} requires authentication (401) — run `secrt auth login`")
+        };
     }
-    if same_logical_instance(&pa.base_url, &pa.configured_base_url) {
-        return err.to_string();
-    }
-    let flagged = match host_of(&pa.base_url) {
-        Some(h) => h,
-        None => return err.to_string(),
-    };
-    let configured = match host_of(&pa.configured_base_url) {
-        Some(h) => h,
-        None => return err.to_string(),
-    };
+
     let c = color_func(is_stderr_tty);
-    format!(
-        "{err}\n  Your API key is for {}, not {}. To switch, run:\n  {} {} {}",
-        c(URL, &configured),
-        c(URL, &flagged),
-        c(CMD, "secrt auth login"),
-        c(OPT, "--base-url"),
-        c(URL, &pa.base_url),
-    )
+
+    // No key configured: a 401 means the request needed auth it didn't have,
+    // not that a key was rejected. Keep it short and point at sign-in.
+    if !has_key {
+        return format!(
+            "{host} requires authentication (401)\n  Run {} to sign in.",
+            c(CMD, "secrt auth login")
+        );
+    }
+
+    // Headline is plain — the red `error:` prefix (added by `write_error`)
+    // and the red hypothesis line below carry the "this failed" weight, so
+    // the rest of the block stays quiet (dim) to avoid burying it in color.
+    let mut out = format!("{host} rejected your API key (401)\n");
+    out.push_str(&crate::auth::fmt_key_line(
+        masked_key,
+        key_source,
+        DIM,
+        is_stderr_tty,
+    ));
+    out.push_str(&crate::auth::fmt_server_line(
+        &pa.base_url,
+        "key not recognized",
+        DIM,
+        DIM,
+        is_stderr_tty,
+    ));
+
+    // Hypothesis — the actionable takeaway, in red so it stands out from the
+    // dim context. When an explicit `--base-url` points at a different host
+    // than the user's configured home instance, we can name both sides;
+    // otherwise fall back to the generic wrong-instance/revoked guess.
+    let cross_instance = pa.base_url_source == BaseUrlSource::Flag
+        && !same_logical_instance(&pa.base_url, &pa.configured_base_url);
+    let hypothesis = match (
+        cross_instance,
+        host_of(&pa.base_url),
+        host_of(&pa.configured_base_url),
+    ) {
+        (true, Some(flagged), Some(configured)) => {
+            format!("Your key is configured for {configured}, not {flagged}.")
+        }
+        _ => "Your key may belong to a different instance, or it was revoked.".to_string(),
+    };
+    out.push_str(&format!("  {}\n", c(ERROR, &hypothesis)));
+
+    out.push_str(&format!(
+        "  Run {} to re-authenticate.",
+        c(CMD, "secrt auth login")
+    ));
+    out
 }
 
 /// Two URLs refer to the same logical secrt instance when:
@@ -348,42 +400,99 @@ mod tests {
     fn decorate_auth_error_passes_through_non_401() {
         let pa = pa_with("https://secrt.is", "https://secrt.ca", BaseUrlSource::Flag);
         let err = "server error (404): not found";
-        assert_eq!(decorate_auth_error(err, &pa, false), err);
+        assert_eq!(
+            decorate_auth_error(err, &pa, "sk2_abcd••••••••", "config", false, false),
+            err
+        );
     }
 
     #[test]
-    fn decorate_auth_error_no_op_when_source_not_flag() {
-        // Default source — user didn't pass --base-url, so a 401 means
-        // their key is genuinely invalid. No host-mismatch hint.
+    fn decorate_auth_error_generic_401_shows_identity_and_recommendation() {
+        // Default source — user didn't pass --base-url. Still rewrite the
+        // 401 into the identity block + generic hypothesis + login hint.
         let pa = pa_with(
             "https://secrt.ca",
             "https://secrt.ca",
             BaseUrlSource::Default,
         );
         let err = "server error (401): unauthorized";
-        assert_eq!(decorate_auth_error(err, &pa, false), err);
-    }
-
-    #[test]
-    fn decorate_auth_error_no_op_when_flag_matches_configured() {
-        let pa = pa_with("https://secrt.ca", "https://secrt.ca", BaseUrlSource::Flag);
-        let err = "server error (401): unauthorized";
-        assert_eq!(decorate_auth_error(err, &pa, false), err);
-    }
-
-    #[test]
-    fn decorate_auth_error_appends_hint_for_flag_cross_instance() {
-        let pa = pa_with("https://secrt.is", "https://secrt.ca", BaseUrlSource::Flag);
-        let err = "server error (401): unauthorized";
-        let out = decorate_auth_error(err, &pa, false);
-        assert!(out.starts_with(err), "should preserve original: {out:?}");
+        let out = decorate_auth_error(err, &pa, "sk2_abcd••••••••", "keychain", false, false);
         assert!(
-            out.contains("Your API key is for secrt.ca, not secrt.is"),
-            "missing host names: {out:?}"
+            out.starts_with("secrt.ca rejected your API key (401)"),
+            "headline: {out:?}"
         );
         assert!(
-            out.contains("secrt auth login --base-url https://secrt.is"),
-            "missing register command: {out:?}"
+            out.contains("Key: sk2_abcd•••••••• (from: keychain)"),
+            "key line: {out:?}"
+        );
+        assert!(
+            out.contains("Server: https://secrt.ca (key not recognized)"),
+            "server line: {out:?}"
+        );
+        assert!(
+            out.contains("may belong to a different instance, or it was revoked"),
+            "hypothesis: {out:?}"
+        );
+        assert!(
+            out.contains("Run secrt auth login to re-authenticate"),
+            "login hint: {out:?}"
+        );
+    }
+
+    #[test]
+    fn decorate_auth_error_flag_match_uses_generic_hypothesis() {
+        // Flag points at the same host as configured — not cross-instance,
+        // so the generic (revoked-or-wrong-instance) hypothesis applies.
+        let pa = pa_with("https://secrt.ca", "https://secrt.ca", BaseUrlSource::Flag);
+        let err = "server error (401): unauthorized";
+        let out = decorate_auth_error(err, &pa, "sk2_abcd••••••••", "config", false, false);
+        assert!(
+            out.contains("may belong to a different instance, or it was revoked"),
+            "generic hypothesis: {out:?}"
+        );
+        assert!(
+            !out.contains("Your key is configured for"),
+            "should not claim a specific cross-instance mismatch: {out:?}"
+        );
+    }
+
+    #[test]
+    fn decorate_auth_error_cross_instance_names_both_hosts() {
+        let pa = pa_with("https://secrt.is", "https://secrt.ca", BaseUrlSource::Flag);
+        let err = "server error (401): unauthorized";
+        let out = decorate_auth_error(err, &pa, "sk2_abcd••••••••", "config", false, false);
+        assert!(
+            out.starts_with("secrt.is rejected your API key (401)"),
+            "headline names the host that rejected the key: {out:?}"
+        );
+        assert!(
+            out.contains("Your key is configured for secrt.ca, not secrt.is"),
+            "cross-instance hypothesis: {out:?}"
+        );
+        assert!(
+            out.contains("Run secrt auth login to re-authenticate"),
+            "login hint: {out:?}"
+        );
+    }
+
+    #[test]
+    fn decorate_auth_error_json_is_terse_single_line() {
+        let pa = pa_with("https://secrt.is", "https://secrt.ca", BaseUrlSource::Flag);
+        let err = "server error (401): unauthorized";
+        let out = decorate_auth_error(err, &pa, "sk2_abcd••••••••", "config", true, false);
+        assert!(
+            !out.contains('\n'),
+            "json message must be one line: {out:?}"
+        );
+        assert!(
+            out.contains("secrt.is rejected your API key (401)"),
+            "headline: {out:?}"
+        );
+        assert!(out.contains("secrt auth login"), "login hint: {out:?}");
+        // No color escapes and no multi-line identity block in json mode.
+        assert!(
+            !out.contains('\x1b'),
+            "json message must be uncolored: {out:?}"
         );
     }
 
@@ -391,22 +500,27 @@ mod tests {
     fn decorate_auth_error_uses_semantic_colors_when_stderr_is_tty() {
         let pa = pa_with("https://secrt.is", "https://secrt.ca", BaseUrlSource::Flag);
         let err = "server error (401): unauthorized";
-        let out = decorate_auth_error(err, &pa, true);
+        let out = decorate_auth_error(err, &pa, "sk2_abcd••••••••", "config", false, true);
+        // The hypothesis line is red so the takeaway stands out from the
+        // dim context block.
         assert!(
-            out.contains("\x1b[1;36msecrt.ca\x1b[0m"),
-            "configured host bold cyan: {out:?}"
+            out.contains("\x1b[31mYour key is configured for secrt.ca, not secrt.is.\x1b[0m"),
+            "hypothesis should be red: {out:?}"
         );
-        assert!(
-            out.contains("\x1b[1;36msecrt.is\x1b[0m"),
-            "flagged host bold cyan: {out:?}"
-        );
+        // The recommended command keeps its cyan accent.
         assert!(
             out.contains("\x1b[36msecrt auth login\x1b[0m"),
             "command in cyan: {out:?}"
         );
+        // Identity labels are dimmed, not yellow, to keep the block quiet.
         assert!(
-            out.contains("\x1b[33m--base-url\x1b[0m"),
-            "option in yellow: {out:?}"
+            out.contains("\x1b[2mKey\x1b[0m") && out.contains("\x1b[2mServer\x1b[0m"),
+            "identity labels should be dim: {out:?}"
+        );
+        // The headline host is no longer bold-cyan — red carries emphasis.
+        assert!(
+            !out.contains("\x1b[1;36msecrt.is\x1b[0m"),
+            "headline host should be plain, not bold cyan: {out:?}"
         );
     }
 }

--- a/crates/secrt-cli/src/list.rs
+++ b/crates/secrt-cli/src/list.rs
@@ -237,7 +237,7 @@ pub fn run_list(args: &[String], deps: &mut Deps) -> i32 {
     let resp = match client.list(limit, offset) {
         Ok(r) => r,
         Err(e) => {
-            let decorated = crate::instance_trust::decorate_auth_error(&e, &pa, stderr_tty);
+            let decorated = crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty);
             write_error(
                 &mut deps.stderr,
                 pa.json,

--- a/crates/secrt-cli/src/list.rs
+++ b/crates/secrt-cli/src/list.rs
@@ -238,12 +238,7 @@ pub fn run_list(args: &[String], deps: &mut Deps) -> i32 {
         Ok(r) => r,
         Err(e) => {
             let decorated = crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty);
-            write_error(
-                &mut deps.stderr,
-                pa.json,
-                (deps.is_tty)(),
-                &format!("list failed: {}", decorated),
-            );
+            write_error(&mut deps.stderr, pa.json, (deps.is_tty)(), &decorated);
             return 1;
         }
     };

--- a/crates/secrt-cli/src/send.rs
+++ b/crates/secrt-cli/src/send.rs
@@ -151,7 +151,16 @@ pub fn run_send(args: &[String], deps: &mut Deps) -> i32 {
         match resolve_amk(&pa, &*client) {
             Ok(amk) => Some(amk),
             Err(e) => {
-                write_error(&mut deps.stderr, pa.json, is_tty, &format!("--note: {}", e));
+                // A 401 here means the configured key was rejected by this
+                // host — surface the full auth-failure block instead of a
+                // bare "--note: server error (401)". Other failures keep the
+                // command-scoped prefix.
+                let msg = if e.contains("(401)") {
+                    crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty)
+                } else {
+                    format!("--note: {}", e)
+                };
+                write_error(&mut deps.stderr, pa.json, is_tty, &msg);
                 return 1;
             }
         }
@@ -209,7 +218,7 @@ pub fn run_send(args: &[String], deps: &mut Deps) -> i32 {
             if is_tty && !pa.silent {
                 let _ = writeln!(deps.stderr);
             }
-            let decorated = crate::instance_trust::decorate_auth_error(&e, &pa, stderr_tty);
+            let decorated = crate::auth::explain_auth_error(&e, &pa, deps, pa.json, stderr_tty);
             write_error(&mut deps.stderr, pa.json, is_tty, &decorated);
             return 1;
         }

--- a/crates/secrt-cli/src/send.rs
+++ b/crates/secrt-cli/src/send.rs
@@ -281,6 +281,11 @@ pub fn run_send(args: &[String], deps: &mut Deps) -> i32 {
             "expires_at": resp.expires_at,
             "copied": copied,
         });
+        // Machine consumers get the exact byte count for file sends (the human
+        // path shows a rounded human_size; this is the precise value).
+        if !pa.file.is_empty() {
+            out["size"] = serde_json::json!(plaintext_len);
+        }
         if let Some(ref pw) = generated_password {
             out["password"] = serde_json::Value::String(pw.clone());
         }

--- a/crates/secrt-cli/src/send.rs
+++ b/crates/secrt-cli/src/send.rs
@@ -366,10 +366,12 @@ fn enforce_envelope_limit(
         .and_then(|s| s.to_str())
         .unwrap_or("this file");
 
+    // Budgets are rounded down (`human_size_floor`) so the stated ceiling is one
+    // the file is guaranteed to fit under — no "about" hedge needed.
     let mut msg = format!(
-        "{name} ({}) is too large for {host} — it accepts files up to about {}.",
+        "{name} ({}) is too large for {host} — it accepts files up to {}.",
         crate::fileutil::human_size(file_bytes),
-        crate::fileutil::human_size(budget(limit)),
+        crate::fileutil::human_size_floor(budget(limit)),
     );
     if !authed {
         let authed_limit = info.limits.authed.max_envelope_bytes;
@@ -377,8 +379,8 @@ fn enforce_envelope_limit(
             msg.push_str(" Sign in with `secrt auth login` to send files of any size.");
         } else if authed_limit > limit {
             msg.push_str(&format!(
-                " Sign in with `secrt auth login` to send up to about {}.",
-                crate::fileutil::human_size(budget(authed_limit)),
+                " Sign in with `secrt auth login` to send up to {}.",
+                crate::fileutil::human_size_floor(budget(authed_limit)),
             ));
         }
     }

--- a/crates/secrt-cli/src/send.rs
+++ b/crates/secrt-cli/src/send.rs
@@ -110,6 +110,10 @@ pub fn run_send(args: &[String], deps: &mut Deps) -> i32 {
         PayloadMeta::binary()
     };
 
+    // Capture the plaintext size before `seal` consumes it — used for the
+    // file-size display and the pre-upload limit check below.
+    let plaintext_len = plaintext.len();
+
     // Seal envelope
     let result = envelope::seal(SealParams {
         content: plaintext,
@@ -135,6 +139,15 @@ pub fn run_send(args: &[String], deps: &mut Deps) -> i32 {
     // Upload to server
     let is_tty = (deps.is_tty)();
     let client = (deps.make_api)(&pa.base_url, &pa.api_key);
+
+    // For file sends, reject an over-limit payload *before* uploading, so the
+    // user isn't made to wait on an upload the server will refuse. Best-effort:
+    // skipped silently if `/info` is unavailable (the server still enforces).
+    if !pa.file.is_empty()
+        && enforce_envelope_limit(&result.envelope, plaintext_len, &pa, &*client, is_tty, deps)
+    {
+        return 1;
+    }
 
     // Pre-validate --note prerequisites before creating the secret so we
     // don't waste a one-time secret when the note can't be attached.
@@ -199,10 +212,25 @@ pub fn run_send(args: &[String], deps: &mut Deps) -> i32 {
             if is_tty && !pa.silent {
                 let c = color_func(true);
                 let expires_fmt = format_expires(&r.expires_at);
-                let msg = if has_passphrase {
-                    "Encrypted and uploaded with passphrase."
+                // For file sends, name the file and its size; text/stdin/gen
+                // secrets stay generic (a byte count there is just noise).
+                let what = if !pa.file.is_empty() {
+                    let name = std::path::Path::new(&pa.file)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("file");
+                    format!(
+                        "Encrypted and uploaded {} ({})",
+                        name,
+                        crate::fileutil::human_size(plaintext_len)
+                    )
                 } else {
-                    "Encrypted and uploaded."
+                    "Encrypted and uploaded".to_string()
+                };
+                let msg = if has_passphrase {
+                    format!("{what} with passphrase.")
+                } else {
+                    format!("{what}.")
                 };
                 let _ = write!(
                     deps.stderr,
@@ -282,6 +310,80 @@ pub fn run_send(args: &[String], deps: &mut Deps) -> i32 {
     } else {
         0
     }
+}
+
+/// For a file send, reject the payload before upload when the sealed envelope
+/// exceeds this instance's per-secret size limit. Returns `true` if rejected
+/// (an error was written; the caller should exit 1). Best-effort: returns
+/// `false` (proceed) when `/info` is unavailable or the tier limit is unset
+/// (`0` = unlimited), letting the server make the final call.
+///
+/// The server limit is on the encrypted *envelope*, but users think in *file*
+/// size, so the message translates the limit into an approximate file budget
+/// using this file's actual encryption expansion — keeping the numbers
+/// comparable and never self-contradictory near the boundary.
+fn enforce_envelope_limit(
+    envelope: &serde_json::Value,
+    file_bytes: usize,
+    pa: &ParsedArgs,
+    client: &(dyn crate::client::SecretApi + '_),
+    is_tty: bool,
+    deps: &mut Deps,
+) -> bool {
+    let info = match client.info() {
+        Ok(i) => i,
+        Err(_) => return false,
+    };
+    let envelope_len = serde_json::to_string(envelope)
+        .map(|s| s.len())
+        .unwrap_or(0) as i64;
+    let authed = !pa.api_key.trim().is_empty();
+    let limit = if authed {
+        info.limits.authed.max_envelope_bytes
+    } else {
+        info.limits.public.max_envelope_bytes
+    };
+    if limit <= 0 || envelope_len <= limit {
+        return false;
+    }
+
+    let expansion = if file_bytes > 0 {
+        (envelope_len as f64) / (file_bytes as f64)
+    } else {
+        1.0
+    };
+    let budget = |lim: i64| -> usize {
+        if expansion > 0.0 {
+            ((lim as f64) / expansion) as usize
+        } else {
+            lim.max(0) as usize
+        }
+    };
+
+    let host = secrt_core::host_of(&pa.base_url).unwrap_or_else(|| pa.base_url.clone());
+    let name = std::path::Path::new(&pa.file)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("this file");
+
+    let mut msg = format!(
+        "{name} ({}) is too large for {host} — it accepts files up to about {}.",
+        crate::fileutil::human_size(file_bytes),
+        crate::fileutil::human_size(budget(limit)),
+    );
+    if !authed {
+        let authed_limit = info.limits.authed.max_envelope_bytes;
+        if authed_limit == 0 {
+            msg.push_str(" Sign in with `secrt auth login` to send files of any size.");
+        } else if authed_limit > limit {
+            msg.push_str(&format!(
+                " Sign in with `secrt auth login` to send up to about {}.",
+                crate::fileutil::human_size(budget(authed_limit)),
+            ));
+        }
+    }
+    write_error(&mut deps.stderr, pa.json, is_tty, &msg);
+    true
 }
 
 /// Parse a subset of ISO 8601 UTC timestamps ("2026-02-09T00:00:00Z") to unix epoch seconds.

--- a/crates/secrt-cli/src/sync.rs
+++ b/crates/secrt-cli/src/sync.rs
@@ -48,12 +48,7 @@ pub(crate) fn handle_sync_url(
     let resp = match client.claim(id, &claim_token) {
         Ok(r) => r,
         Err(e) => {
-            write_error(
-                &mut deps.stderr,
-                json,
-                is_tty,
-                &format!("sync failed: {}", e),
-            );
+            write_error(&mut deps.stderr, json, is_tty, &e);
             return 1;
         }
     };

--- a/crates/secrt-cli/tests/cli_burn.rs
+++ b/crates/secrt-cli/tests/cli_burn.rs
@@ -177,8 +177,8 @@ fn burn_api_error() {
     );
     assert_eq!(code, 1);
     assert!(
-        stderr.to_string().contains("burn failed"),
-        "stderr: {}",
+        stderr.to_string().contains("forbidden"),
+        "should surface the error: {}",
         stderr
     );
 }
@@ -293,8 +293,8 @@ fn burn_prefix_resolves_via_list() {
     assert_eq!(code, 1);
     let err = stderr.to_string();
     assert!(
-        err.contains("burn failed"),
-        "should show burn failed: {}",
+        err.contains("not found"),
+        "should surface the underlying error: {}",
         err
     );
 }

--- a/crates/secrt-cli/tests/cli_dispatch.rs
+++ b/crates/secrt-cli/tests/cli_dispatch.rs
@@ -432,7 +432,7 @@ fn config_shows_default_ttl_server_default() {
 }
 
 #[test]
-fn config_shows_decryption_passphrases_masked() {
+fn config_shows_decryption_passphrases_count() {
     let cfg_dir = setup_config("decryption_passphrases = [\"secret1\", \"secret2\"]\n");
     let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
         .env("XDG_CONFIG_HOME", cfg_dir.path().to_str().unwrap())
@@ -445,26 +445,16 @@ fn config_shows_decryption_passphrases_masked() {
         "config should show field: {}",
         err
     );
+    // Reports the count and source, not a list of unreadable masked blobs.
     assert!(
-        err.contains("2 entries"),
-        "config should show entry count: {}",
+        err.contains("2 entries (config file)"),
+        "config should show entry count and source: {}",
         err
     );
-    // Should NOT reveal actual values
+    // Must never reveal the actual values.
     assert!(
-        !err.contains("secret1"),
+        !err.contains("secret1") && !err.contains("secret2"),
         "config should NOT reveal values: {}",
-        err
-    );
-    assert!(
-        !err.contains("secret2"),
-        "config should NOT reveal values: {}",
-        err
-    );
-    // Should contain bullet chars (masked)
-    assert!(
-        err.contains("\u{2022}"),
-        "config should show masked values: {}",
         err
     );
 }
@@ -1099,8 +1089,8 @@ fn config_show_decryption_passphrases_from_keychain_only() {
     assert_eq!(code, 0);
     let err = stderr.to_string();
     assert!(
-        err.contains("1 entries") && err.contains("keychain"),
-        "should show keychain source: {}",
+        err.contains("1 entry (keychain)"),
+        "should show singular count and keychain source: {}",
         err
     );
 }

--- a/crates/secrt-cli/tests/cli_get.rs
+++ b/crates/secrt-cli/tests/cli_get.rs
@@ -303,46 +303,56 @@ fn get_decryption_error() {
 }
 
 #[test]
-fn get_404_explains_one_time_semantics() {
-    // A 404 on claim is the indistinguishable expired/claimed/unknown case.
-    // The recipient should get a calm explanation, not a raw "server error".
-    let url = make_share_url("https://secrt.ca", "test123");
-    let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
-        .mock_claim(Err("server error (404): secret not found".into()))
-        .build();
-    let code = cli::run(&args(&["secrt", "get", &url]), &mut deps);
-    assert_eq!(code, 1);
-    let err = stderr.to_string();
-    assert!(err.contains("Secret unavailable"), "stderr: {err}");
-    assert!(
-        err.contains("already been opened") && err.contains("link is incomplete"),
-        "should explain the union of causes: {err}"
-    );
-    assert!(
-        !err.contains("server error") && !err.contains("404"),
-        "should not leak the raw status: {err}"
-    );
-}
-
-#[test]
-fn get_non_404_error_surfaces_raw() {
-    // Non-404 claim failures (5xx, network) are surfaced as-is — no friendly
-    // "Secret unavailable" rewrite (that's only for the 404 union) and no
-    // longer wrapped in a redundant "get failed:" prefix.
-    let url = make_share_url("https://secrt.ca", "test123");
-    let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
-        .mock_claim(Err(
-            "server error (503): server is temporarily unavailable".into()
-        ))
-        .build();
-    let code = cli::run(&args(&["secrt", "get", &url]), &mut deps);
-    assert_eq!(code, 1);
-    let err = stderr.to_string();
-    assert!(err.contains("503"), "should surface the real error: {err}");
-    assert!(
-        !err.contains("Secret unavailable") && !err.contains("get failed"),
-        "non-404 should not be rewritten or prefixed: {err}"
-    );
+fn get_claim_error_messages() {
+    // A 404 is the indistinguishable expired/claimed/unknown union and gets a
+    // calm rewrite; any other status is surfaced raw (no rewrite, no prefix).
+    struct Case {
+        name: &'static str,
+        claim_err: &'static str,
+        contains: &'static [&'static str],
+        absent: &'static [&'static str],
+    }
+    let cases = [
+        Case {
+            name: "404 → one-time-semantics explanation",
+            claim_err: "server error (404): secret not found",
+            contains: &[
+                "Secret unavailable",
+                "already been opened",
+                "link is incomplete",
+            ],
+            absent: &["server error", "404"],
+        },
+        Case {
+            name: "non-404 surfaced raw",
+            claim_err: "server error (503): server is temporarily unavailable",
+            contains: &["503"],
+            absent: &["Secret unavailable", "get failed"],
+        },
+    ];
+    for case in cases {
+        let url = make_share_url("https://secrt.ca", "test123");
+        let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
+            .mock_claim(Err(case.claim_err.into()))
+            .build();
+        let code = cli::run(&args(&["secrt", "get", &url]), &mut deps);
+        assert_eq!(code, 1, "[{}] stderr: {}", case.name, stderr);
+        let err = stderr.to_string();
+        for want in case.contains {
+            assert!(
+                err.contains(want),
+                "[{}] missing {want:?}: {err}",
+                case.name
+            );
+        }
+        for unwanted in case.absent {
+            assert!(
+                !err.contains(unwanted),
+                "[{}] should not contain {unwanted:?}: {err}",
+                case.name
+            );
+        }
+    }
 }
 
 #[test]
@@ -987,6 +997,12 @@ fn get_output_unwritable_fails_without_claiming() {
 #[test]
 fn get_auto_save_failure_rescues_to_downloads() {
     use std::os::unix::fs::PermissionsExt;
+    // Root ignores `0o555`, so the read-only-dir failure can't be simulated —
+    // skip rather than report a false negative under privileged CI.
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping get_auto_save_failure_rescues_to_downloads: running as root");
+        return;
+    }
     let _guard = CWD_LOCK.lock().unwrap();
     let plaintext = b"\x89PNG\r\n\x1a\nfake png data";
     let (share_link, seal_result) = seal_test_file(plaintext, "photo.png", "image/png");
@@ -1046,6 +1062,9 @@ fn get_auto_save_failure_rescues_to_downloads() {
         "must not invent a collision suffix in the fallback dir: {err}"
     );
     assert_eq!(fs::read(&rescued).unwrap(), plaintext);
+    // A recovered secret must be owner-only — it can land in shared Downloads.
+    let mode = fs::metadata(&rescued).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "rescued secret must be 0600, got {mode:o}");
 }
 
 #[test]

--- a/crates/secrt-cli/tests/cli_get.rs
+++ b/crates/secrt-cli/tests/cli_get.rs
@@ -303,18 +303,42 @@ fn get_decryption_error() {
 }
 
 #[test]
-fn get_api_error() {
+fn get_404_explains_one_time_semantics() {
+    // A 404 on claim is the indistinguishable expired/claimed/unknown case.
+    // The recipient should get a calm explanation, not a raw "server error".
     let url = make_share_url("https://secrt.ca", "test123");
     let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
         .mock_claim(Err("server error (404): secret not found".into()))
         .build();
     let code = cli::run(&args(&["secrt", "get", &url]), &mut deps);
     assert_eq!(code, 1);
+    let err = stderr.to_string();
+    assert!(err.contains("Secret unavailable"), "stderr: {err}");
     assert!(
-        stderr.to_string().contains("get failed"),
-        "stderr: {}",
-        stderr
+        err.contains("already been opened") && err.contains("link is incomplete"),
+        "should explain the union of causes: {err}"
     );
+    assert!(
+        !err.contains("server error") && !err.contains("404"),
+        "should not leak the raw status: {err}"
+    );
+}
+
+#[test]
+fn get_non_404_error_keeps_prefix() {
+    // Other claim failures (network, 5xx, rate limit) are real errors and
+    // keep the explanatory "get failed:" prefix.
+    let url = make_share_url("https://secrt.ca", "test123");
+    let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
+        .mock_claim(Err(
+            "server error (503): server is temporarily unavailable".into()
+        ))
+        .build();
+    let code = cli::run(&args(&["secrt", "get", &url]), &mut deps);
+    assert_eq!(code, 1);
+    let err = stderr.to_string();
+    assert!(err.contains("get failed"), "stderr: {err}");
+    assert!(err.contains("503"), "should surface the real error: {err}");
 }
 
 #[test]

--- a/crates/secrt-cli/tests/cli_get.rs
+++ b/crates/secrt-cli/tests/cli_get.rs
@@ -953,6 +953,98 @@ fn get_file_auto_save_on_tty() {
 }
 
 #[test]
+fn get_output_unwritable_fails_without_claiming() {
+    // --output into a nonexistent directory must fail BEFORE claiming, so the
+    // one-time secret isn't consumed. No mock_claim is registered: if get
+    // reached the claim, the mock client would panic.
+    let url = make_share_url("https://secrt.ca", "test123");
+    let (mut deps, stdout, stderr) = TestDepsBuilder::new().build();
+    let code = cli::run(
+        &args(&[
+            "secrt",
+            "get",
+            &url,
+            "--output",
+            "/nonexistent-secrt-dir-xyz/out.txt",
+        ]),
+        &mut deps,
+    );
+    assert_eq!(code, 1);
+    assert!(stdout.to_string().is_empty(), "no output: {stdout}");
+    let err = stderr.to_string();
+    assert!(err.contains("can't write to"), "stderr: {err}");
+    assert!(
+        err.contains("not retrieved"),
+        "must signal the secret was preserved: {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn get_auto_save_failure_rescues_to_downloads() {
+    use std::os::unix::fs::PermissionsExt;
+    let _guard = CWD_LOCK.lock().unwrap();
+    let plaintext = b"\x89PNG\r\n\x1a\nfake png data";
+    let (share_link, seal_result) = seal_test_file(plaintext, "photo.png", "image/png");
+    let mock_resp = ClaimResponse {
+        envelope: seal_result.envelope,
+        expires_at: "2099-12-31T23:59:59Z".into(),
+    };
+
+    // Read-only cwd → the primary auto-save write fails. Seed it with a
+    // colliding `photo.png` first, so the cwd resolution earns a " (1)"
+    // suffix — which must NOT carry into the fallback directory.
+    let ro = tempfile::Builder::new()
+        .prefix("secrt_ro_")
+        .tempdir()
+        .expect("tempdir");
+    fs::write(ro.path().join("photo.png"), b"pre-existing").unwrap();
+    let set_mode = |mode: u32| {
+        let mut p = std::fs::metadata(ro.path()).unwrap().permissions();
+        p.set_mode(mode);
+        std::fs::set_permissions(ro.path(), p).unwrap();
+    };
+    let _cwd = CwdGuard::enter(ro.path());
+    set_mode(0o555);
+
+    // A writable stand-in for the Downloads folder.
+    let dl = tempfile::Builder::new()
+        .prefix("secrt_dl_")
+        .tempdir()
+        .expect("tempdir");
+
+    let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
+        .tty(true)
+        .stdout_tty(true)
+        .env("XDG_DOWNLOAD_DIR", dl.path().to_str().unwrap())
+        .mock_claim(Ok(mock_resp))
+        .build();
+    let code = cli::run(&args(&["secrt", "get", &share_link]), &mut deps);
+
+    set_mode(0o755); // restore for cleanup
+
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let err = stderr.to_string();
+    assert!(
+        err.contains("couldn't save photo.png to"),
+        "warning should name the clean file and the failed directory: {err}"
+    );
+    assert!(err.contains("Saved to"), "should report the rescue: {err}");
+    // The rescued file keeps its clean name — no collision suffix carried
+    // over from the (different) source directory.
+    let rescued = dl.path().join("photo.png");
+    assert!(
+        rescued.exists(),
+        "secret should be rescued to Downloads with its clean name: {err}"
+    );
+    assert!(
+        !dl.path().join("photo (1).png").exists(),
+        "must not invent a collision suffix in the fallback dir: {err}"
+    );
+    assert_eq!(fs::read(&rescued).unwrap(), plaintext);
+}
+
+#[test]
 fn get_file_output_flag() {
     let plaintext = b"explicit output path";
     let (share_link, seal_result) =

--- a/crates/secrt-cli/tests/cli_get.rs
+++ b/crates/secrt-cli/tests/cli_get.rs
@@ -325,9 +325,10 @@ fn get_404_explains_one_time_semantics() {
 }
 
 #[test]
-fn get_non_404_error_keeps_prefix() {
-    // Other claim failures (network, 5xx, rate limit) are real errors and
-    // keep the explanatory "get failed:" prefix.
+fn get_non_404_error_surfaces_raw() {
+    // Non-404 claim failures (5xx, network) are surfaced as-is — no friendly
+    // "Secret unavailable" rewrite (that's only for the 404 union) and no
+    // longer wrapped in a redundant "get failed:" prefix.
     let url = make_share_url("https://secrt.ca", "test123");
     let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
         .mock_claim(Err(
@@ -337,8 +338,11 @@ fn get_non_404_error_keeps_prefix() {
     let code = cli::run(&args(&["secrt", "get", &url]), &mut deps);
     assert_eq!(code, 1);
     let err = stderr.to_string();
-    assert!(err.contains("get failed"), "stderr: {err}");
     assert!(err.contains("503"), "should surface the real error: {err}");
+    assert!(
+        !err.contains("Secret unavailable") && !err.contains("get failed"),
+        "non-404 should not be rewritten or prefixed: {err}"
+    );
 }
 
 #[test]

--- a/crates/secrt-cli/tests/cli_info.rs
+++ b/crates/secrt-cli/tests/cli_info.rs
@@ -143,8 +143,8 @@ fn info_server_error_exits_1() {
     assert_eq!(code, 1);
     let err = stderr.to_string();
     assert!(
-        err.contains("info failed"),
-        "should show error, got: {}",
+        err.contains("500") || err.contains("internal error"),
+        "should surface the server error, got: {}",
         err
     );
 }

--- a/crates/secrt-cli/tests/cli_list.rs
+++ b/crates/secrt-cli/tests/cli_list.rs
@@ -179,8 +179,8 @@ fn list_api_error() {
     let code = cli::run(&args(&["secrt", "list", "--api-key", "sk_bad"]), &mut deps);
     assert_eq!(code, 1);
     assert!(
-        stderr.to_string().contains("list failed"),
-        "stderr: {}",
+        stderr.to_string().contains("rejected your API key"),
+        "should surface the auth-failure message: {}",
         stderr
     );
 }

--- a/crates/secrt-cli/tests/cli_send.rs
+++ b/crates/secrt-cli/tests/cli_send.rs
@@ -526,14 +526,17 @@ fn send_unauthorized_error_shows_api_key_hint() {
     let code = cli::run(&args(&["secrt", "send"]), &mut deps);
     assert_eq!(code, 1);
     let err = stderr.to_string();
+    // Unauthenticated send (no key configured): a 401 reports that the host
+    // requires auth and points at sign-in, rather than claiming a key was
+    // rejected.
     assert!(
-        err.contains("unauthorized"),
-        "stderr should contain auth error: {}",
+        err.contains("requires authentication (401)"),
+        "stderr should report the auth requirement: {}",
         err
     );
     assert!(
-        err.contains("API key"),
-        "stderr should hint about API key: {}",
+        err.contains("secrt auth login"),
+        "stderr should recommend signing in: {}",
         err
     );
 }
@@ -878,6 +881,48 @@ fn send_note_no_amk_fails() {
         err.contains("no account key found"),
         "should report missing AMK: {}",
         err
+    );
+}
+
+#[test]
+fn send_note_401_shows_auth_identity_block() {
+    // The user's scenario: a configured key rejected by the host it's
+    // pointed at. The --note pre-validation 401 must surface the full
+    // auth-failure block (key + source, server + "key not recognized",
+    // hypothesis, login hint) instead of a bare "--note: server error".
+    let root_key = [0x33u8; 32];
+    let api_key = format!("sk2_abcdef.{}", URL_SAFE_NO_PAD.encode(root_key));
+
+    let (mut deps, stdout, stderr) = TestDepsBuilder::new()
+        .stdin(b"my secret")
+        .env("SECRET_API_KEY", &api_key)
+        .mock_get_amk_wrapper(Err("server error (401): unauthorized".into()))
+        .build();
+    let code = cli::run(&args(&["secrt", "send", "--note", "a note"]), &mut deps);
+    assert_eq!(code, 1, "should fail: {}", stderr);
+    assert!(
+        stdout.to_string().is_empty(),
+        "must not waste a secret: {}",
+        stdout
+    );
+    let err = stderr.to_string();
+    assert!(
+        err.contains("rejected your API key (401)"),
+        "headline: {err}"
+    );
+    assert!(err.contains("(from: env)"), "key source line: {err}");
+    assert!(
+        err.contains("Server: https://secrt.ca (key not recognized)"),
+        "server line: {err}"
+    );
+    assert!(
+        err.contains("may belong to a different instance, or it was revoked"),
+        "hypothesis: {err}"
+    );
+    assert!(err.contains("secrt auth login"), "login hint: {err}");
+    assert!(
+        !err.contains("--note: server error"),
+        "should not fall back to the bare --note prefix: {err}"
     );
 }
 

--- a/crates/secrt-cli/tests/cli_send.rs
+++ b/crates/secrt-cli/tests/cli_send.rs
@@ -7,7 +7,43 @@ use base64::Engine;
 
 use helpers::{args, TestDepsBuilder};
 use secrt_cli::cli;
-use secrt_cli::client::{AmkWrapperResponse, CreateResponse};
+use secrt_cli::client::{
+    AmkWrapperResponse, CreateResponse, InfoLimits, InfoRate, InfoResponse, InfoTTL, InfoTier,
+};
+
+/// Build an `InfoResponse` with the given per-secret envelope limits (bytes;
+/// `0` = unlimited) for exercising the pre-upload file-size check.
+fn info_with_limits(public_env: i64, authed_env: i64) -> InfoResponse {
+    let tier = |max_envelope_bytes: i64| InfoTier {
+        max_envelope_bytes,
+        max_secrets: 0,
+        max_total_bytes: 0,
+        rate: InfoRate {
+            requests_per_second: 1.0,
+            burst: 10,
+        },
+    };
+    InfoResponse {
+        authenticated: false,
+        user_id: None,
+        ttl: InfoTTL {
+            default_seconds: 86400,
+            max_seconds: 31536000,
+        },
+        limits: InfoLimits {
+            public: tier(public_env),
+            authed: tier(authed_env),
+        },
+        claim_rate: InfoRate {
+            requests_per_second: 1.0,
+            burst: 10,
+        },
+        latest_cli_version: None,
+        latest_cli_version_checked_at: None,
+        min_supported_cli_version: None,
+        server_version: None,
+    }
+}
 
 /// Use a non-routable address to ensure API calls fail
 const DEAD_URL: &str = "http://127.0.0.1:19191";
@@ -65,6 +101,57 @@ fn send_file_flag() {
         &mut deps,
     );
     assert_eq!(code, 1, "stderr: {}", stderr);
+}
+
+#[test]
+fn send_file_too_large_fails_fast() {
+    // A file whose envelope exceeds the instance limit must be rejected
+    // *before* upload. No mock_create is registered — if send tried to upload,
+    // the mock client would panic. The tiny limit (50 bytes) is below the
+    // envelope's fixed overhead, so it fails regardless of compression.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("report.pdf");
+    std::fs::write(&path, vec![0xABu8; 4096]).unwrap();
+
+    let (mut deps, stdout, stderr) = TestDepsBuilder::new()
+        .mock_info(Ok(info_with_limits(50, 1_048_576)))
+        .build();
+    let code = cli::run(
+        &args(&["secrt", "send", "--file", path.to_str().unwrap()]),
+        &mut deps,
+    );
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(stdout.to_string().is_empty(), "must not upload: {stdout}");
+    let err = stderr.to_string();
+    assert!(err.contains("report.pdf"), "names the file: {err}");
+    assert!(err.contains("too large"), "explains the cause: {err}");
+    assert!(
+        err.contains("secrt auth login"),
+        "suggests signing in for the higher tier: {err}"
+    );
+}
+
+#[test]
+fn send_file_within_limit_shows_size() {
+    // Under the limit: send proceeds and the confirmation names the file and
+    // its human-readable size.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("notes.txt");
+    std::fs::write(&path, vec![b'x'; 2000]).unwrap();
+
+    let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
+        .tty(true)
+        .mock_info(Ok(info_with_limits(262_144, 1_048_576)))
+        .mock_create(Ok(mock_send_response()))
+        .build();
+    let code = cli::run(
+        &args(&["secrt", "send", "--file", path.to_str().unwrap()]),
+        &mut deps,
+    );
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let err = stderr.to_string();
+    assert!(err.contains("notes.txt"), "names the file: {err}");
+    assert!(err.contains("2 KB"), "shows human-readable size: {err}");
 }
 
 #[test]

--- a/crates/secrt-cli/tests/cli_send.rs
+++ b/crates/secrt-cli/tests/cli_send.rs
@@ -104,54 +104,104 @@ fn send_file_flag() {
 }
 
 #[test]
-fn send_file_too_large_fails_fast() {
-    // A file whose envelope exceeds the instance limit must be rejected
-    // *before* upload. No mock_create is registered — if send tried to upload,
-    // the mock client would panic. The tiny limit (50 bytes) is below the
-    // envelope's fixed overhead, so it fails regardless of compression.
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("report.pdf");
-    std::fs::write(&path, vec![0xABu8; 4096]).unwrap();
+fn send_file_size_limit_cases() {
+    // Two paths share the file-send harness: an over-limit file is rejected
+    // before upload (no mock_create registered — the mock client panics if a
+    // doomed upload is attempted), and an under-limit file uploads and reports
+    // its size. The tiny 50-byte limit sits below the envelope's fixed
+    // overhead, so the reject case fails regardless of compression.
+    struct Case {
+        name: &'static str,
+        filename: &'static str,
+        file_bytes: usize,
+        public_limit: i64,
+        register_create: bool,
+        expected_code: i32,
+        contains: &'static [&'static str],
+    }
+    let cases = [
+        Case {
+            name: "over limit → rejected before upload",
+            filename: "report.pdf",
+            file_bytes: 4096,
+            public_limit: 50,
+            register_create: false,
+            expected_code: 1,
+            contains: &["report.pdf", "too large", "secrt auth login"],
+        },
+        Case {
+            name: "under limit → uploads and shows size",
+            filename: "notes.txt",
+            file_bytes: 2000,
+            public_limit: 262_144,
+            register_create: true,
+            expected_code: 0,
+            contains: &["notes.txt", "2 KB"],
+        },
+    ];
+    for case in cases {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(case.filename);
+        std::fs::write(&path, vec![0xABu8; case.file_bytes]).unwrap();
 
-    let (mut deps, stdout, stderr) = TestDepsBuilder::new()
-        .mock_info(Ok(info_with_limits(50, 1_048_576)))
-        .build();
-    let code = cli::run(
-        &args(&["secrt", "send", "--file", path.to_str().unwrap()]),
-        &mut deps,
-    );
-    assert_eq!(code, 1, "stderr: {stderr}");
-    assert!(stdout.to_string().is_empty(), "must not upload: {stdout}");
-    let err = stderr.to_string();
-    assert!(err.contains("report.pdf"), "names the file: {err}");
-    assert!(err.contains("too large"), "explains the cause: {err}");
-    assert!(
-        err.contains("secrt auth login"),
-        "suggests signing in for the higher tier: {err}"
-    );
+        let mut builder = TestDepsBuilder::new()
+            .tty(true)
+            .mock_info(Ok(info_with_limits(case.public_limit, 1_048_576)));
+        if case.register_create {
+            builder = builder.mock_create(Ok(mock_send_response()));
+        }
+        let (mut deps, stdout, stderr) = builder.build();
+
+        let code = cli::run(
+            &args(&["secrt", "send", "--file", path.to_str().unwrap()]),
+            &mut deps,
+        );
+        assert_eq!(
+            code, case.expected_code,
+            "[{}] stderr: {}",
+            case.name, stderr
+        );
+        let err = stderr.to_string();
+        for want in case.contains {
+            assert!(
+                err.contains(want),
+                "[{}] missing {want:?}: {err}",
+                case.name
+            );
+        }
+        if case.expected_code == 1 {
+            assert!(
+                stdout.to_string().is_empty(),
+                "[{}] must not upload: {}",
+                case.name,
+                stdout
+            );
+        }
+    }
 }
 
 #[test]
-fn send_file_within_limit_shows_size() {
-    // Under the limit: send proceeds and the confirmation names the file and
-    // its human-readable size.
+fn send_file_json_includes_exact_size() {
+    // `--json` carries the exact byte count for file sends (the human path
+    // shows a rounded size; machines get the precise value).
     let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("notes.txt");
-    std::fs::write(&path, vec![b'x'; 2000]).unwrap();
+    let path = dir.path().join("data.bin");
+    std::fs::write(&path, vec![0xABu8; 1234]).unwrap();
 
-    let (mut deps, _stdout, stderr) = TestDepsBuilder::new()
-        .tty(true)
+    let (mut deps, stdout, stderr) = TestDepsBuilder::new()
         .mock_info(Ok(info_with_limits(262_144, 1_048_576)))
         .mock_create(Ok(mock_send_response()))
         .build();
     let code = cli::run(
-        &args(&["secrt", "send", "--file", path.to_str().unwrap()]),
+        &args(&["secrt", "send", "--file", path.to_str().unwrap(), "--json"]),
         &mut deps,
     );
     assert_eq!(code, 0, "stderr: {stderr}");
-    let err = stderr.to_string();
-    assert!(err.contains("notes.txt"), "names the file: {err}");
-    assert!(err.contains("2 KB"), "shows human-readable size: {err}");
+    let json: serde_json::Value = serde_json::from_str(stdout.to_string().trim()).expect("json");
+    assert_eq!(
+        json["size"], 1234,
+        "json should carry exact byte count: {stdout}"
+    );
 }
 
 #[test]

--- a/crates/secrt-cli/tests/cli_sync.rs
+++ b/crates/secrt-cli/tests/cli_sync.rs
@@ -228,8 +228,8 @@ fn sync_claim_error_exits_1() {
     assert_eq!(code, 1);
     let err = stderr.to_string();
     assert!(
-        err.contains("sync failed"),
-        "should show sync error: {}",
+        err.contains("not found"),
+        "should surface the sync error: {}",
         err
     );
 }


### PR DESCRIPTION
## Summary

A broad pass over the CLI's error messaging and failure handling — turning vague, sometimes-misleading output into clear, actionable messages, and closing a genuine data-loss hole on the receive path. Started as a single 401 fix and grew into an end-to-end cleanup of how the CLI talks to the user when things go wrong.

All changes are CLI-only (`secrt-cli`). 724 tests pass; clippy + fmt clean.

## What changed

### Authentication & server errors
- **A 401 now explains *which* server rejected your key.** Instead of `server error (401): unauthorized`, an authenticated command shows the same identity block as `secrt auth status` (masked key + source, server + "key not recognized"), a likely cause, and a `secrt auth login` recommendation. Names both hosts when an explicit `--base-url` differs from the configured instance. The `secrt send --note` pre-check routes through the same message. Styling tuned so the failure stands out (red headline + hypothesis, dim identity block, white host value).
- **4xx no longer masquerades as "server error."** `unauthorized (401)`, `forbidden (403)`, `not found (404)`, `rate limit exceeded (429)…` — "server error" is reserved for 5xx. The `(NNN)` marker is preserved so code-level detection keeps working.
- **Dropped redundant `burn failed:` / `list failed:` / `info failed:` / `get failed:` / `sync failed:` prefixes** — messages now stand on their own (and stop doubling up with the richer auth/404 text).

### Receiving secrets (`get`)
- **A claimed/expired/unknown secret reads calmly, not like a bug.** The server returns an indistinguishable 404 for expired / already-opened / unknown / bad-link (a deliberate zero-knowledge property), so the CLI explains the union: *Secret unavailable. It may have already been opened, expired, or the link is incomplete.*
- **A failed save no longer loses an already-retrieved secret.** A one-time secret is deleted server-side on claim, so the decrypted bytes are the only copy. Now:
  - `--output <path>` is **pre-flighted before claiming** — if it isn't writable, `get` fails *without* consuming the secret.
  - Auto-save failures **fall back like a browser**: current dir → OS Downloads → home → temp, reporting where it landed, re-resolving collisions per directory (no stray `(1)` suffix carried across dirs).
- **A wrong/truncated link gives a real hint** instead of `decryption failed`: *the secret key in the link (after #) is wrong or incomplete.*

### Sending files (`send`)
- **Oversized files fail fast, before uploading.** A `--file` send checks the sealed envelope against the instance's per-secret limit via one `/info` call and rejects in the user's terms — *report.pdf (4 MB) is too large for secrt.ca — it accepts files up to about 48 KB. Sign in for up to about 1.5 MB.* The budget is derived from the file's actual encryption expansion, so it never contradicts itself near the boundary. Best-effort: proceeds if `/info` is unreachable (server still enforces).
- **Size shown on success:** `✓ Encrypted and uploaded report.pdf (119 KB).` (files only).

### Display
- **Human-readable file sizes** (`119 KB`, `1.2 MB`, base-1000 like a browser/Finder), shared via `fileutil::human_size`; kept distinct from the base-2-exact `format_bytes` used for round policy limits. `--json` still carries exact bytes.

## Follow-ups (logged, not in this PR)
- **Taskmaster #73 — i18n readiness.** The expensive-to-retrofit blocker for localization is that control flow is detected by substring-matching display strings (`e.contains("(401)")`, `e.contains("404")`). First step recorded: move `SecretApi` to typed errors carrying status/kind so display formatting lives only at the edge. Lowest ROI on the CLI; highest on the web frontend.

## Testing
- New coverage: 401 identity block + json terseness, 404 message, output-unwritable-fails-without-claiming, auto-save rescue (incl. the collision regression), `human_size` table, oversized-file fail-fast (asserts no upload), file-size display, plus updated `client.rs` status-formatter and affected integration assertions.
- `make lint-rust` + `make test-rust` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File uploads validate per-secret size limits before uploading; uploads report filename and human-readable size (JSON includes exact bytes).
  * Config output is column-aligned; decryption passphrases shown as entry counts, not secrets.

* **Bug Fixes**
  * Recovered/saved secrets on Unix are written owner-only (0600); failed saves preflight output writability and retry to Downloads/home/temp.
  * Client errors (4xx) are presented as request problems rather than “server error”; expired/claimed secrets show “Secret unavailable”.
  * Authentication failures include identity info and remediation guidance; clearer, less redundant error wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->