### PR TITLE
chore(ci): pin Swatinem/rust-cache to v2.9.1 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           toolchain: 1.95.0
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -72,7 +72,7 @@ jobs:
       # pinned toolchain on first invocation.
       - name: Install Rust cross-target
         run: rustup target add ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           key: ${{ matrix.target }}
 

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           key: ${{ matrix.target }}
 


### PR DESCRIPTION
Clears the GitHub Actions Node 20 deprecation annotation.

The Node 20 warning on the build jobs comes transitively from `Swatinem/rust-cache@v2`, which bundled `actions/cache@v4` running on Node 20 (forced to Node 24 on 2026-06-16, Node 20 removed 2026-09-16). rust-cache **v2.9.0** migrated to the node24 runner; this pins to **v2.9.1** across `ci.yml`, `release-cli.yml`, and `release-server.yml`.

Deliberately **not** touching `azure/trusted-signing-action@v0.5.0` — it wasn't flagged as Node 20, and its latest (v2.0.0) is a major bump with breaking input changes in the Windows code-signing path; that warrants its own careful change + test release.

No code or release impact. The `windows-latest → windows-2025-vs2026` redirect notice is informational and needs no action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to improve build efficiency through dependency caching enhancements across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->